### PR TITLE
fix: attach from terminals missing remote terminfo

### DIFF
--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -310,10 +311,10 @@ func attach(drv driver.Driver, id string) {
 		if runErr == nil {
 			return
 		}
-		// A session that was interactive and then dropped fails slow; only an
-		// instant failure reads as "not online yet" — and only once: if it
-		// still fails after reachability was confirmed, waiting won't fix it.
-		if retried || time.Since(start) > 15*time.Second {
+		// ssh uses 255 for a transport failure. Other quick failures came from
+		// the remote command (for example tmux rejecting TERM), so waiting for
+		// reachability would only hide the real error and run it a second time.
+		if retried || !retryAttach(runErr, time.Since(start)) {
 			fmt.Fprintln(os.Stderr, ui.Bad.Render("pier:"), "attach:", runErr)
 			return
 		}
@@ -323,6 +324,11 @@ func attach(drv driver.Driver, id string) {
 			fatal(err)
 		}
 	}
+}
+
+func retryAttach(err error, elapsed time.Duration) bool {
+	var exitErr *exec.ExitError
+	return elapsed <= 15*time.Second && errors.As(err, &exitErr) && exitErr.ExitCode() == 255
 }
 
 // waitReachable polls a no-op exec until ssh-over-SSM answers.

--- a/cmd/pier/main_test.go
+++ b/cmd/pier/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestRetryAttachOnlyForQuickSSHTransportFailure(t *testing.T) {
+	exit := func(code string) error {
+		return exec.Command("sh", "-c", "exit "+code).Run()
+	}
+	if !retryAttach(exit("255"), time.Second) {
+		t.Error("quick ssh transport failure should retry")
+	}
+	if retryAttach(exit("1"), time.Second) {
+		t.Error("remote command failure should not retry")
+	}
+	if retryAttach(exit("255"), 16*time.Second) {
+		t.Error("slow transport failure should not retry")
+	}
+}

--- a/internal/driver/awsec2/direct_test.go
+++ b/internal/driver/awsec2/direct_test.go
@@ -41,6 +41,18 @@ func TestSSHOptsTransports(t *testing.T) {
 	}
 }
 
+func TestAttachCommandFallsBackForUnknownTerminal(t *testing.T) {
+	d := &Driver{StateDir: t.TempDir()}
+	cmd, err := d.AttachCommand(context.Background(), "i-0abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remote := cmd.Args[len(cmd.Args)-1]
+	if !strings.Contains(remote, `infocmp "$TERM"`) || !strings.Contains(remote, "export TERM=xterm-256color") {
+		t.Errorf("attach must fall back when the VM lacks the client's terminfo entry, got %q", remote)
+	}
+}
+
 // Park, resume and resize invalidate the probe cache — a cached success
 // otherwise points connections at the old public IP for up to a TTL after
 // the instance comes back on a new one.

--- a/internal/driver/awsec2/driver.go
+++ b/internal/driver/awsec2/driver.go
@@ -289,6 +289,10 @@ func (d *Driver) Destroy(ctx context.Context, id string) error {
 func (d *Driver) AttachCommand(ctx context.Context, id string) (*exec.Cmd, error) {
 	const remote = `[ -S "$SSH_AUTH_SOCK" ] && ln -sf "$SSH_AUTH_SOCK" ~/.ssh/agent.sock
 [ -e "$HOME/.pier-bootstrapped" ] || { echo "pier: this session is still setting up — attach again when it shows running in pier ls" >&2; exit 1; }
+# SSH forwards the client's TERM, but newer terminals (for example Ghostty)
+# may not exist in the VM image's terminfo database yet. Keep the richer entry
+# when it is installed and otherwise use the portable 256-colour baseline.
+if ! infocmp "$TERM" >/dev/null 2>&1; then export TERM=xterm-256color; fi
 exec tmux new-session -A -s main`
 	args := append(d.sshOpts(ctx, id), "-t", "-o", "ForwardAgent=yes", "agent@"+id, remote)
 	cmd := exec.CommandContext(ctx, "ssh", args...)


### PR DESCRIPTION
## Summary

- fall back to `xterm-256color` when the remote VM lacks the client terminal's terminfo entry
- only show the reachability retry for actual SSH transport failures
- cover terminal fallback and retry classification with tests

## Verification

- `go vet ./...`
- `go test ./...`
- `git diff --check`