### PR TITLE
Auto-start Docker Compose projects during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,25 +211,35 @@ resuming checkout-flow (~20-30s)...
 
 ## Making your repo pier-ready
 
-Three optional files at the repo root, all committed:
+Four optional files at the repo root, all committed:
 
 | File | Runs / read | Contains |
 |---|---|---|
 | `.pier-setup.sh` | Every session's first boot, async, in a `setup` tmux window | Repo state: deps, services, migrations, seeds |
 | `.pier-include` | At create | Untracked/ignored files to carry (env files, local certs) |
 | `.pier-bake.sh` | Once, during `pier bake` | Toolchains beyond the default image (pnpm, python, rust, ...) |
+| `.pier.toml` | At create | Repo-specific behavior, including the Docker Compose opt-out |
 
 ```bash
 # .pier-setup.sh (cwd is the repo root, logs to ~/.pier-setup.log)
 set -euo pipefail
 pnpm install
-docker compose up -d
-pnpm db:migrate
+pnpm build
 ```
 
-Prefer `docker compose up -d` for services. A bare background process must
-fully detach with `setsid cmd </dev/null >log 2>&1 &` or it dies when the
-setup window closes.
+When a conventional Compose file is present (`compose.yaml`, `compose.yml`,
+`docker-compose.yaml`, or `docker-compose.yml`), pier runs `docker compose up
+-d` automatically after the setup hook succeeds. For a repo that must control
+the order itself, opt out and put the Compose command in `.pier-setup.sh`:
+
+```toml
+# .pier.toml
+[docker]
+auto_up = false
+```
+
+A bare background process must fully detach with `setsid cmd </dev/null >log
+2>&1 &` or it dies when the setup window closes.
 
 ```
 # .pier-include: one path or glob per line (no **), a directory carries its subtree
@@ -249,7 +259,7 @@ COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install -g pnpm@10.6.5
 
 Don't write those files by hand. This repo ships
 [`skills/pier-onboard`](skills/pier-onboard/SKILL.md), a skill that teaches
-a coding agent to inspect your repo and write all three files with the right
+a coding agent to inspect your repo and write the applicable files with the right
 boundaries.
 
 ```
@@ -339,8 +349,9 @@ supersedes the old image, and `pier teardown` sweeps them all by tag.
 ### Setup that can't fail silently
 
 `.pier-setup.sh` runs async in its own tmux window on first boot, after the
-checkout, dirty patch, and `.pier-include` files are in place. The outcome
-always surfaces:
+checkout, dirty patch, and `.pier-include` files are in place. If it succeeds,
+pier then starts a detected Docker Compose project unless `.pier.toml` opts
+out. The outcome of the whole sequence always surfaces:
 
 - `pier ls` and the TUI show `(setup running)` or `(setup failed)`
 - `~/.pier-setup.log` ends with `pier setup: done` or `pier setup: FAILED (exit N)`

--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -212,6 +212,10 @@ func cmdNew(args []string) {
 
 	cfg, drv := loadDriver()
 	repo := repoRoot()
+	repoCfg, err := config.LoadRepo(repo)
+	if err != nil {
+		fatal(err)
+	}
 	// ctrl-c mid-create must cancel the ctx (not just kill the process) so
 	// Create's deferred cleanup can terminate the half-made instance.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -249,7 +253,8 @@ func cmdNew(args []string) {
 		ui.Dim.Render(fmt.Sprintf("(%s @ %s)", filepath.Base(repo), base)))
 	sess, err := drv.Create(ctx, driver.CreateSpec{
 		Name: branch, Repo: repo, Branch: branch, BaseRef: base, Image: image,
-		IdleTimeout: idle, UnattendedCap: cap_,
+		DisableAutoCompose: !repoCfg.AutoCompose(),
+		IdleTimeout:        idle, UnattendedCap: cap_,
 		Progress: func(step string) { fmt.Println(ui.Step(step)) },
 	})
 	if err != nil {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -252,10 +252,14 @@ numbers in §14).
    secrets tar while it boots; push and bootstrap the moment sshd answers;
    `.pier-setup.sh` runs asynchronously in a background tmux window while you
    type to the agent — it starts only after the checkout, dirty patch, and
-   `.pier-include` extras are all in place. `PIER_SETUP_SCRIPT`
+   `.pier-include` extras are all in place. After the hook succeeds, a repo
+   with `compose.yaml`, `compose.yml`, `docker-compose.yaml`, or
+   `docker-compose.yml` is started with `docker compose up -d`. This defaults
+   on; `[docker] auto_up = false` in repo-root `.pier.toml` opts out.
+   `PIER_SETUP_SCRIPT`
    points it at a different script — relative to the repo root or `~` —
    which travels in the tar and takes precedence over the repo's own.
-   The outcome is never silent: the window writes `~/.pier-setup.status`
+   The outcome of the hook-plus-Compose sequence is never silent: the window writes `~/.pier-setup.status`
    ("running", then the exit code — the supervisor beacons it, so `ls`/TUI
    show "(setup running)"/"(setup failed)"), ends `~/.pier-setup.log` with
    `pier setup: done`/`FAILED (exit N)`, and on failure renames itself to

--- a/internal/config/repo.go
+++ b/internal/config/repo.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// RepoConfig contains the optional, repository-local pier settings. It is
+// intentionally separate from Config: ~/.config/pier/config.toml describes a
+// developer's cloud account, while .pier.toml travels with one repository.
+type RepoConfig struct {
+	Docker RepoDockerConfig `toml:"docker"`
+}
+
+type RepoDockerConfig struct {
+	// Pointer preserves the distinction between the default (true) and an
+	// explicit opt-out.
+	AutoUp *bool `toml:"auto_up"`
+}
+
+// LoadRepo reads <root>/.pier.toml. A missing file is the default config.
+func LoadRepo(root string) (RepoConfig, error) {
+	var cfg RepoConfig
+	path := filepath.Join(root, ".pier.toml")
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return cfg, fmt.Errorf("read %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// AutoCompose reports whether a repository's Compose project should be
+// started after its setup hook. Automatic startup is on unless opted out.
+func (c RepoConfig) AutoCompose() bool {
+	return c.Docker.AutoUp == nil || *c.Docker.AutoUp
+}

--- a/internal/config/repo_test.go
+++ b/internal/config/repo_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadRepoAutoCompose(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "missing config defaults on", want: true},
+		{name: "empty config defaults on", body: "# repository settings\n", want: true},
+		{name: "explicit on", body: "[docker]\nauto_up = true\n", want: true},
+		{name: "explicit opt out", body: "[docker]\nauto_up = false\n", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			if tt.body != "" {
+				if err := os.WriteFile(filepath.Join(root, ".pier.toml"), []byte(tt.body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cfg, err := LoadRepo(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := cfg.AutoCompose(); got != tt.want {
+				t.Errorf("AutoCompose() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadRepoRejectsInvalidTOML(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".pier.toml")
+	if err := os.WriteFile(path, []byte("[docker\nauto_up = false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadRepo(root)
+	if err == nil || !strings.Contains(err.Error(), path) {
+		t.Fatalf("LoadRepo() error = %v, want error naming %s", err, path)
+	}
+}

--- a/internal/driver/awsec2/create.go
+++ b/internal/driver/awsec2/create.go
@@ -564,23 +564,64 @@ fi
 # first attach forwards an agent; harmless when it never does).
 tmux has-session -t main 2>/dev/null || tmux new-session -d -s main -e "SSH_AUTH_SOCK=$HOME/.ssh/agent.sock" -c "$HOME/work/{{REPO}}"
 # Background setup, after checkout + patch + .pier-include extras are all in
-# place: the repo's .pier-setup.sh, unless a PIER_SETUP_SCRIPT override rode
-# the tar (outer double quotes expand $setup now, into the single-quoted
-# bash -c; \$ defers the rest to run time). The outcome must be impossible to
-# miss — a failed setup used to vanish with its window: ~/.pier-setup.status
-# holds "running" then the exit code (the supervisor beacons it to ls/TUI),
-# the log's last line says done/FAILED, and a failed window renames to
-# setup-failed and stays open instead of closing. The rename targets its own
-# pane id: with a client attached, a bare rename-window can resolve "current
-# window" to the attached client's window and mislabel the user's shell.
+# place. Run the repo hook first, then start Docker Compose automatically when
+# one of its conventional files is present. A repo can opt out in .pier.toml.
+# Keeping this in a script (rather than a nested bash -c one-liner) makes the
+# order and failure behavior explicit and leaves something useful to inspect.
 setup=./.pier-setup.sh
 if [ -f "$HOME/.config/pier/setup.sh" ]; then setup="$HOME/.config/pier/setup.sh"; fi
-# Presence is the signal, not the exec bit: git only carries +x when the
-# author remembered chmod, and gating on -x skipped a committed 0644
-# .pier-setup.sh with no trace — the one silent failure setup promises not
-# to have. bash runs it either way.
-if [ -f "$setup" ]; then
-  tmux new-window -d -t main -n setup "bash -c 'set -a; . ~/.config/pier/env 2>/dev/null; set +a; cd ~/work/{{REPO}} || exit 1; echo running > ~/.pier-setup.status; bash $setup 2>&1 | tee ~/.pier-setup.log; c=\${PIPESTATUS[0]}; echo \$c > ~/.pier-setup.status; if [ \$c -eq 0 ]; then echo \"pier setup: done\" >> ~/.pier-setup.log; else echo \"pier setup: FAILED (exit \$c)\" | tee -a ~/.pier-setup.log; tmux rename-window -t \$TMUX_PANE setup-failed; exec sleep infinity; fi'"
+auto_compose={{AUTO_COMPOSE}}
+compose_file=
+if [ "$auto_compose" = 1 ]; then
+  for candidate in compose.yaml compose.yml docker-compose.yaml docker-compose.yml; do
+    if [ -f "$candidate" ]; then compose_file="$candidate"; break; fi
+  done
+fi
+# Presence is the signal for a setup hook, not its exec bit: bash can run a
+# committed 0644 script. Don't create a setup window when neither action is
+# needed.
+if [ -f "$setup" ] || [ -n "$compose_file" ]; then
+  mkdir -p "$HOME/.config/pier"
+  cat > "$HOME/.config/pier/run-setup.sh" <<'PIER_SETUP'
+#!/usr/bin/env bash
+set -uo pipefail
+set -a; . "$HOME/.config/pier/env" 2>/dev/null || true; set +a
+cd "$HOME/work/{{REPO}}" || exit 1
+
+setup=./.pier-setup.sh
+if [ -f "$HOME/.config/pier/setup.sh" ]; then setup="$HOME/.config/pier/setup.sh"; fi
+auto_compose={{AUTO_COMPOSE}}
+
+run_setup() {
+  if [ -f "$setup" ]; then
+    bash "$setup" || return $?
+  fi
+  if [ "$auto_compose" = 1 ]; then
+    for candidate in compose.yaml compose.yml docker-compose.yaml docker-compose.yml; do
+      if [ -f "$candidate" ]; then
+        echo "pier setup: starting docker compose ($candidate)"
+        docker compose up -d
+        return $?
+      fi
+    done
+  fi
+  return 0
+}
+
+echo running > "$HOME/.pier-setup.status"
+run_setup 2>&1 | tee "$HOME/.pier-setup.log"
+c=${PIPESTATUS[0]}
+echo "$c" > "$HOME/.pier-setup.status"
+if [ "$c" -eq 0 ]; then
+  echo "pier setup: done" >> "$HOME/.pier-setup.log"
+else
+  echo "pier setup: FAILED (exit $c)" | tee -a "$HOME/.pier-setup.log"
+  tmux rename-window -t "$TMUX_PANE" setup-failed
+  exec sleep infinity
+fi
+PIER_SETUP
+  chmod 0700 "$HOME/.config/pier/run-setup.sh"
+  tmux new-window -d -t main -n setup "bash ~/.config/pier/run-setup.sh"
 fi
 
 # Attach gates on this marker: nobody lands in a half-set-up session. Written
@@ -607,6 +648,10 @@ func renderBootstrap(spec driver.CreateSpec, mode, sha, origin string) string {
 	}
 	line("config", "user.name")
 	line("config", "user.email")
+	autoCompose := "1"
+	if spec.DisableAutoCompose {
+		autoCompose = "0"
+	}
 	return strings.NewReplacer(
 		"{{REPO}}", filepath.Base(spec.Repo),
 		"{{BRANCH}}", spec.Branch,
@@ -615,6 +660,7 @@ func renderBootstrap(spec driver.CreateSpec, mode, sha, origin string) string {
 		"{{SHA}}", sha,
 		"{{ORIGIN}}", origin,
 		"{{EXPORTREF}}", exportRef(spec.Name),
+		"{{AUTO_COMPOSE}}", autoCompose,
 	).Replace(bootstrapTmpl)
 }
 

--- a/internal/driver/awsec2/create_test.go
+++ b/internal/driver/awsec2/create_test.go
@@ -157,24 +157,27 @@ func TestRenderBootstrapModes(t *testing.T) {
 		"git remote add origin 'https://github.com/o/r'",
 		"git reset -q --hard abc123",
 		`[projects."/home/agent/work/myrepo"]`, // codex pre-trust
-		// Setup outcome must be written for the beacon and the log, and its
-		// shell variables must survive rendering escaped — they belong to the
-		// tmux window's bash, not to the bootstrap shell.
-		`echo running > ~/.pier-setup.status`,
+		// Setup outcome must be written for the beacon and the log.
+		`echo running > "$HOME/.pier-setup.status"`,
 		// Runs on presence via bash: a committed 0644 .pier-setup.sh (git
 		// only carries +x when the author set it) must not skip silently.
-		`if [ -f "$setup" ]; then`,
-		`bash $setup 2>&1`,
+		`if [ -f "$setup" ] || [ -n "$compose_file" ]; then`,
+		`bash "$setup"`,
+		// Compose is automatic by default and recognizes every conventional
+		// filename while letting Docker apply its own precedence rules.
+		`auto_compose=1`,
+		`docker compose up -d`,
+		`compose.yaml compose.yml docker-compose.yaml docker-compose.yml`,
 		// The cloud-init wait must guard on binaries the stock image LACKS
 		// (Ubuntu ships git/tmux, so those never triggered the wait and
 		// setup raced the installs it depends on).
 		`command -v docker >/dev/null && command -v node >/dev/null && command -v claude >/dev/null || sudo cloud-init status --wait`,
-		`c=\${PIPESTATUS[0]}`,
-		`pier setup: FAILED (exit \$c)`,
+		`c=${PIPESTATUS[0]}`,
+		`pier setup: FAILED (exit $c)`,
 		// The failure rename must target its own pane: a bare rename-window
 		// resolved to the attached client's current window and mislabeled
 		// the user's shell as setup-failed.
-		`tmux rename-window -t \$TMUX_PANE setup-failed`,
+		`tmux rename-window -t "$TMUX_PANE" setup-failed`,
 	} {
 		if !strings.Contains(origin, want) {
 			t.Errorf("origin-mode bootstrap missing %q", want)
@@ -183,12 +186,34 @@ func TestRenderBootstrapModes(t *testing.T) {
 	if strings.Contains(origin, "origin) git fetch -q /tmp/pier.bundle") {
 		t.Error("origin mode must not fetch a bundle")
 	}
+	if hook, compose := strings.Index(origin, `bash "$setup"`), strings.Index(origin, "docker compose up -d"); hook < 0 || compose < 0 || hook > compose {
+		t.Error("repository setup hook must run before docker compose")
+	}
+
+	disabledSpec := spec
+	disabledSpec.DisableAutoCompose = true
+	disabled := renderBootstrap(disabledSpec, "origin", "abc123", "https://github.com/o/r")
+	if !strings.Contains(disabled, "auto_compose=0") || strings.Contains(disabled, "auto_compose=1") {
+		t.Error("DisableAutoCompose must render the runtime opt-out")
+	}
 
 	full := renderBootstrap(spec, "full", "abc123", "")
 	// The ref carries the session name: concurrent creates in one repo must
 	// not race on a shared refs/pier/export.
 	if !strings.Contains(full, "git fetch -q /tmp/pier.bundle refs/pier/export-x") {
 		t.Error("full-mode bootstrap must fetch the bundle by this create's export ref")
+	}
+}
+
+func TestRenderBootstrapShellSyntax(t *testing.T) {
+	script := renderBootstrap(
+		driver.CreateSpec{Name: "x", Repo: "/tmp/myrepo", Branch: "feat"},
+		"origin", "abc123", "https://github.com/o/r",
+	)
+	cmd := exec.Command("bash", "-n")
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("rendered bootstrap is not valid bash: %v\n%s", err, out)
 	}
 }
 

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -57,14 +57,17 @@ type Machine struct {
 // is attach-ready; code push and .pier-setup.sh continue asynchronously in
 // the session (the async create pipeline) with steps streamed via Progress.
 type CreateSpec struct {
-	Name          string
-	Repo          string        // local repo root; the bundle source
-	Branch        string        // new branch, off BaseRef
-	BaseRef       string        // default: HEAD
-	Image         string        // the repo's baked image ID; "" = stock (guarded cloud-init installs everything)
-	IdleTimeout   time.Duration // 0 = never auto-park
-	UnattendedCap time.Duration // 0 = no runaway cap
-	Progress      func(step string)
+	Name    string
+	Repo    string // local repo root; the bundle source
+	Branch  string // new branch, off BaseRef
+	BaseRef string // default: HEAD
+	Image   string // the repo's baked image ID; "" = stock (guarded cloud-init installs everything)
+	// DisableAutoCompose opts a repository out of the default first-boot
+	// `docker compose up -d` when a Compose file is present.
+	DisableAutoCompose bool
+	IdleTimeout        time.Duration // 0 = never auto-park
+	UnattendedCap      time.Duration // 0 = no runaway cap
+	Progress           func(step string)
 }
 
 // BakeSpec describes one repo's image bake. Images are repo-specific: the

--- a/skills/pier-onboard/SKILL.md
+++ b/skills/pier-onboard/SKILL.md
@@ -1,22 +1,23 @@
 ---
 name: pier-onboard
-description: Set up a repository for pier — inspect the project and write its .pier-setup.sh, .pier-include, and .pier-bake.sh so pier sessions boot ready to work. Use when asked to set up, onboard, or configure pier for a repo.
+description: Set up a repository for pier — inspect the project and write its .pier-setup.sh, .pier-include, .pier-bake.sh, and optional .pier.toml so pier sessions boot ready to work. Use when asked to set up, onboard, or configure pier for a repo.
 ---
 
 # Onboard a repository to pier
 
 pier runs coding-agent sessions as micro-VMs on the user's own AWS account.
 When a session is created, the repo is checked out on the VM, uncommitted
-edits arrive as a patch, and three optional repo-root files control the rest:
+edits arrive as a patch, and four optional repo-root files control the rest:
 
 | File | When it runs / travels | What belongs in it |
 |---|---|---|
 | `.pier-bake.sh` | Once, during `pier bake`, on a throwaway instance that becomes the repo's AMI | **Toolchains** — language runtimes, package managers |
 | `.pier-setup.sh` | On every session's first boot, async, after the repo lands | **Repo state** — dependency install, services, migrations, seeds |
 | `.pier-include` | List read at create time; matching files ride to the VM | **Untracked/ignored files** dev needs — env files, local certs |
+| `.pier.toml` | Read at create time | **Repo behavior** — currently the Docker Compose auto-start opt-out |
 
 Your job: inspect this repo, write the files that apply, and tell the user
-what to run next. All three are optional — write only what the repo needs.
+what to run next. All four are optional — write only what the repo needs.
 
 ## Step 1 — inspect the repo
 
@@ -32,8 +33,8 @@ From that, determine:
    reinstall these. Anything else the build needs — pnpm/yarn, python,
    uv, rust, java — goes in `.pier-bake.sh`.
 2. **The dev-setup sequence** — the commands a human runs after a fresh
-   clone (install deps, start services, migrate, seed). That's
-   `.pier-setup.sh`.
+   clone (install deps, migrate, seed). That's `.pier-setup.sh`. Pier starts a
+   conventional Docker Compose project after that hook succeeds.
 3. **Files git doesn't carry** that dev needs — usually `.env*`. That's
    `.pier-include`. Nothing untracked or gitignored ships unless listed
    here; pier prints which env files it is *not* carrying at create time.
@@ -80,13 +81,23 @@ duplicating its steps. Typical shape:
 # boot, cwd = repo root. Logs to ~/.pier-setup.log.
 set -euo pipefail
 pnpm install
-docker compose up -d
-pnpm db:migrate
+pnpm build
 ```
 
 Everything must be non-interactive — no prompts, no `sudo` that asks, no
-watch-mode/foreground processes. Run services with `docker compose up -d`
-where possible. A bare background process must fully detach —
+watch-mode/foreground processes. If the repo contains `compose.yaml`,
+`compose.yml`, `docker-compose.yaml`, or `docker-compose.yml`, pier runs
+`docker compose up -d` automatically after this hook succeeds. If setup must
+control the Compose ordering itself, also write:
+
+```toml
+# .pier.toml
+[docker]
+auto_up = false
+```
+
+Then put `docker compose up -d` in `.pier-setup.sh` at the required point. A
+bare background process must fully detach —
 `setsid cmd </dev/null >log 2>&1 &` — because the setup tmux window closes
 when the script ends and SIGHUPs its process group (`nohup` alone does not
 detach it).


### PR DESCRIPTION
## Summary
- start conventional Docker Compose projects after a repository setup hook succeeds
- add a repository-local `.pier.toml` opt-out with `[docker] auto_up = false`
- preserve setup status/log/failure-window behavior and document the new default

## Validation
- `make test`
- `make build`
- rendered bootstrap checked with `bash -n`