### PR TITLE
fix: dereference included file symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ setup window closes.
 apps/*/.env.local
 ```
 
+A file symlink matched directly by a line or glob is dereferenced: its target
+contents arrive as a regular file at the symlink's repository path. Directory
+symlinks are never followed.
+
 ```bash
 # .pier-bake.sh (agent user, passwordless sudo, NO repo checkout yet)
 set -euo pipefail

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -316,7 +316,9 @@ and the IAP tunnel are simply slower).
    ignored files travel **only** when a repo-root **`.pier-include`** names
    them: one path or glob per line, matched against the disk with no
    git-status distinction — listed = travels, extracted after checkout +
-   patch so listed content wins. Nothing loose ships by default — no env
+   patch so listed content wins. Directly matched file symlinks are
+   dereferenced into regular files at their repo-relative paths; directory
+   symlinks are not followed. Nothing loose ships by default — no env
    auto-transfer; the create prints which env files it is *not* carrying so
    a missing one fails loud at create, not deep in `make dev`.
 
@@ -331,7 +333,9 @@ written back. Sources (wizard-detected, confirmed into the manifest):
 - repo files named by a repo-root `.pier-include` (path or glob per line) —
   the **only** loose-file channel: nothing untracked or ignored ships without
   a line here (env files included; the create warns about ones left behind).
-  Tracked content arrives with the fetch, dirty edits to it via the patch.
+  Directly matched file symlinks carry their target contents under the link's
+  repo-relative path. Tracked content arrives with the fetch, dirty edits to
+  it via the patch.
 - `~/.codex/` (auth.json, config.toml)
 - `~/.claude/` settings, `CLAUDE.md`, agents
 - a GitHub credential for git push/PRs and private-repo fetch: `gh auth

--- a/internal/driver/payload/files.go
+++ b/internal/driver/payload/files.go
@@ -125,9 +125,12 @@ func portableMCP(servers map[string]json.RawMessage) map[string]json.RawMessage 
 // ships without a line here (tracked content arrives via the fetch, dirty
 // edits to it via the patch). One path or glob per line (relative to the
 // root; * ? [] per segment, no **), # comments, a directory line carries its
-// whole subtree. A listed path travels as it sits on disk — no git-status
-// distinction — and the tar extracts after checkout + patch, so listed
-// content wins. No file, or an empty one, means nothing extra travels.
+// whole subtree. A file symlink directly matched by a line or glob is
+// dereferenced and carried as a regular file at the symlink's repo-relative
+// path; directory symlinks and nested symlinks discovered while walking a
+// directory are not followed. A listed path travels with no git-status
+// distinction, and the tar extracts after checkout + patch, so listed content
+// wins. No file, or an empty one, means nothing extra travels.
 func pierIncludeFiles(repoRoot string) []string {
 	b, err := os.ReadFile(filepath.Join(repoRoot, ".pier-include"))
 	if err != nil {
@@ -140,9 +143,12 @@ func pierIncludeFiles(repoRoot string) []string {
 			continue
 		}
 		// WalkDir on a glob match handles files and directories uniformly
-		// (a file path walks as just itself); .git and non-regular skipped.
+		// (a file path walks as just itself). Only a symlink that is itself a
+		// match is eligible: directory walks must not escape through links in
+		// their subtrees.
 		matches, _ := filepath.Glob(filepath.Join(repoRoot, line))
 		for _, m := range matches {
+			match := filepath.Clean(m)
 			_ = filepath.WalkDir(m, func(path string, e fs.DirEntry, err error) error {
 				if err != nil {
 					return nil
@@ -153,7 +159,12 @@ func pierIncludeFiles(repoRoot string) []string {
 					}
 					return nil
 				}
-				if !e.Type().IsRegular() {
+				if e.Type()&fs.ModeSymlink != 0 {
+					target, statErr := os.Stat(path)
+					if filepath.Clean(path) != match || statErr != nil || !target.Mode().IsRegular() {
+						return nil
+					}
+				} else if !e.Type().IsRegular() {
 					return nil
 				}
 				if rel, err := filepath.Rel(repoRoot, path); err == nil && filepath.IsLocal(rel) {

--- a/internal/driver/payload/payload_test.go
+++ b/internal/driver/payload/payload_test.go
@@ -375,6 +375,73 @@ func TestPierInclude(t *testing.T) {
 	}
 }
 
+func TestPierIncludeDereferencesDirectFileSymlinks(t *testing.T) {
+	root := t.TempDir()
+	sources := t.TempDir()
+	target := filepath.Join(sources, "api.env")
+	if err := os.WriteFile(target, []byte("API_KEY=local\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "apps", "api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "uploads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for link, destination := range map[string]string{
+		"apps/api/.env": target,
+		"broken":        filepath.Join(sources, "missing"),
+		"source-dir":    sources,
+		"uploads/.env":  target,
+	} {
+		if err := os.Symlink(destination, filepath.Join(root, link)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, ".pier-include"),
+		[]byte("apps/*/.env\nbroken\nsource-dir\nuploads/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The glob directly matches apps/api/.env, so its target is carried.
+	// Broken and directory links are ineligible, and the uploads directory
+	// walk must not follow the nested link it encounters.
+	if got, want := pierIncludeFiles(root), []string{"apps/api/.env"}; !slices.Equal(got, want) {
+		t.Fatalf("pierIncludeFiles() = %v, want %v", got, want)
+	}
+
+	dst := filepath.Join(t.TempDir(), "files.tar")
+	if err := buildFilesTar(dst, nil, root, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	tr := tar.NewReader(f)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			t.Fatal("repo/apps/api/.env missing from files tar")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header.Name != "repo/apps/api/.env" {
+			continue
+		}
+		contents, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header.Typeflag != tar.TypeReg || string(contents) != "API_KEY=local\n" {
+			t.Fatalf("carried symlink = type %d, contents %q", header.Typeflag, contents)
+		}
+		break
+	}
+}
+
 // Carried repo files must land world-readable (exec kept for scripts): the
 // VM's docker daemon is userns-remapped, so a 0600 .env that works under
 // Docker Desktop bind-mounts unreadable to every container on the VM.

--- a/skills/pier-onboard/SKILL.md
+++ b/skills/pier-onboard/SKILL.md
@@ -96,7 +96,9 @@ detach it).
 One path or glob per line, relative to the repo root. `*`, `?`, `[]` match
 within a path segment — **no `**`**. A directory line carries its whole
 subtree. `#` starts a comment. Listed files travel exactly as they sit on
-disk and win over the checkout. Example:
+disk and win over the checkout. A file symlink matched directly by a line or
+glob is dereferenced into a regular file at the same repository path;
+directory symlinks are not followed. Example:
 
 ```
 # env files docker compose and the apps read


### PR DESCRIPTION
## Summary

Dereference file symlinks that are directly matched by `.pier-include`, storing their target bytes as regular files at the symlink paths on the instance. Directory symlinks, broken links, and symlinks merely encountered while traversing an included directory remain excluded, so directory walks cannot escape through links.

Documentation now describes the behavior in the README, specification, and onboarding skill.

## Testing

- `make test`
- `make build`
- `git diff --check`