### PR TITLE
tui: full-screen on the alt screen; detach returns to the list

### DIFF
--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -311,11 +311,13 @@ func repoRoot() string {
 	return strings.TrimSpace(string(out))
 }
 
-// attach runs the interactive ssh+tmux. A fresh or just-resumed VM reports
-// cloud-running before its transport answers (EC2's SSM agent takes ~30s to
-// register; GCE's IAP tunnel has the same window), so an ssh attempt that
-// dies instantly gets one bounded wait-for-reachability and a retry instead
-// of a raw transport error dump.
+// attach runs the interactive ssh+tmux for the CLI paths (pier attach,
+// pier <branch>); the TUI has its own tea.ExecProcess flow wired through
+// tui.Options so a detach lands back on the list. A fresh or just-resumed VM
+// reports cloud-running before its transport answers (EC2's SSM agent takes
+// ~30s to register; GCE's IAP tunnel has the same window), so an ssh attempt
+// that dies instantly gets one bounded wait-for-reachability and a retry
+// instead of a raw transport error dump.
 func attach(drv driver.Driver, id string) {
 	fmt.Println(ui.Dim.Render("attaching — detach with C-b d (session keeps running)"))
 	retried := false
@@ -919,7 +921,7 @@ func confirm(prompt string, def bool) bool {
 
 func cmdTUI() {
 	_, drv := loadDriver()
-	action, err := tui.Run(tui.Options{
+	err := tui.Run(tui.Options{
 		// Async: the TUI opens instantly and the quota fills in when it lands.
 		FetchQuota: func() string {
 			q, err := drv.Headroom(context.Background())
@@ -960,16 +962,19 @@ func cmdTUI() {
 			}
 			return out, err
 		},
+		Attach: func(s driver.Session) (*exec.Cmd, error) {
+			return drv.AttachCommand(context.Background(), s.ID)
+		},
+		Resume: func(s driver.Session) error {
+			return drv.Resume(context.Background(), s.ID)
+		},
+		RetryAttach: retryAttach,
+		WaitReachable: func(s driver.Session) error {
+			return waitReachable(drv, s.ID, 4*time.Minute)
+		},
 	})
 	if err != nil {
 		fatal(err)
-	}
-	switch action.Kind {
-	case tui.ActionAttach:
-		resumeIfParked(drv, action.Session)
-		attach(drv, action.Session.ID)
-	case tui.ActionNew:
-		cmdNew([]string{action.Branch})
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,12 +1,17 @@
 // Package tui is the bare `pier` screen: a session list you can attach to,
-// plus new/delete/pin/refresh. Inline (no full-screen takeover), one accent
-// color, states color-coded. Quota loads asynchronously so the screen opens
-// instantly; a `loaded` flag separates "fetching" from "genuinely empty" so
-// the list never flashes "0 sessions" before the first fetch lands.
+// plus new/delete/pin/refresh. Full-screen on the alternate buffer, one
+// accent color, states color-coded; quitting restores the shell untouched.
+// Attach hands the terminal to ssh via tea.ExecProcess, so a tmux detach
+// lands back on this list instead of the shell. Quota loads asynchronously
+// so the screen opens instantly; a `loaded` flag separates "fetching" from
+// "genuinely empty" so the list never flashes "0 sessions" before the first
+// fetch lands.
 package tui
 
 import (
+	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -25,7 +30,7 @@ type Options struct {
 	Pin        func(driver.Session) error
 	// CreateDetached starts a background create and returns its log path;
 	// the TUI stays open and the session appears in the list as "creating".
-	// nil falls back to quit-and-create-in-foreground (ActionNew).
+	// nil disables creating from the TUI (tests).
 	CreateDetached func(branch string) (logPath string, err error)
 	// Resize + Machines power the m key: Machines lists same-arch picks for a
 	// session so nobody memorizes type names. nil hides the key.
@@ -34,30 +39,21 @@ type Options struct {
 	// FetchLog returns a session's setup log for the l key's in-place viewer.
 	// nil hides the key.
 	FetchLog func(s driver.Session) (string, error)
+	// Attach returns a fresh ssh command for one attach attempt; the TUI runs
+	// it via tea.ExecProcess so the program survives a detach and lands back
+	// on the list. nil disables the enter key (tests).
+	Attach func(s driver.Session) (*exec.Cmd, error)
+	// Resume unparks a session's VM and blocks until its transport answers.
+	Resume func(s driver.Session) error
+	// RetryAttach + WaitReachable power the one bounded reconnect after a fast
+	// ssh transport failure (fresh or just-resumed VMs); nil disables the retry.
+	RetryAttach   func(err error, elapsed time.Duration) bool
+	WaitReachable func(s driver.Session) error
 }
 
-type ActionKind int
-
-const (
-	ActionNone ActionKind = iota
-	ActionAttach
-	ActionNew
-)
-
-// Action is what the user picked; attach/new run after the TUI returns the
-// terminal (ssh needs it).
-type Action struct {
-	Kind    ActionKind
-	Session driver.Session
-	Branch  string
-}
-
-func Run(opts Options) (Action, error) {
-	final, err := tea.NewProgram(model{opts: opts, loading: true}).Run()
-	if err != nil {
-		return Action{}, err
-	}
-	return final.(model).action, nil
+func Run(opts Options) error {
+	_, err := tea.NewProgram(model{opts: opts, loading: true}, tea.WithAltScreen()).Run()
+	return err
 }
 
 type mode int
@@ -85,7 +81,10 @@ type model struct {
 	polling   bool // an auto-refresh poll is scheduled (creates in flight)
 	watch     int  // poll rounds left after a spawn (until it's listable)
 	frame     int  // spinner frame
-	action    Action
+	// attach-in-flight state; enter is a no-op while attachSess is set
+	attachSess    driver.Session // row being attached; zero Name = none in flight
+	attachStart   time.Time      // last ExecProcess launch; feeds RetryAttach
+	attachRetried bool           // one bounded reconnect per attach, like the CLI
 	// settings page state; cfg loads fresh each time s opens the page
 	cfg      *config.Config
 	setIdx   int
@@ -134,6 +133,25 @@ type spawnedMsg struct {
 	branch string
 	log    string
 	err    error
+}
+
+// resumedMsg reports a parked VM's blocking resume finished (or failed).
+type resumedMsg struct {
+	s   driver.Session
+	err error
+}
+
+// attachDoneMsg arrives when the foreground ssh exits: detach, remote exit,
+// or transport error.
+type attachDoneMsg struct {
+	s   driver.Session
+	err error
+}
+
+// reachableMsg reports the bounded wait before the one attach retry.
+type reachableMsg struct {
+	s   driver.Session
+	err error
 }
 
 func tickCmd() tea.Cmd {
@@ -207,6 +225,48 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case quotaMsg:
 		m.quota = string(msg)
 		return m, nil
+	case resumedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.attachSess = driver.Session{}
+			m.status, m.statusBad = "resume "+msg.s.Name+": "+msg.err.Error(), true
+			return m, nil
+		}
+		return m.startAttach(msg.s)
+	case attachDoneMsg:
+		if msg.err == nil { // clean detach or remote exit
+			m.attachSess, m.attachRetried = driver.Session{}, false
+			m.loading = true
+			m.status, m.statusBad = "detached from "+msg.s.Name+" — it keeps running", false
+			return m, tea.Batch(m.fetch, tickCmd())
+		}
+		if !m.attachRetried && m.opts.RetryAttach != nil && m.opts.WaitReachable != nil &&
+			m.opts.RetryAttach(msg.err, time.Since(m.attachStart)) {
+			m.attachRetried = true
+			m.loading = true
+			m.status, m.statusBad = "not reachable yet — waiting for "+msg.s.Name+" to come online (~30-60s)", false
+			wait := m.opts.WaitReachable
+			return m, tea.Batch(tickCmd(), func() tea.Msg { return reachableMsg{msg.s, wait(msg.s)} })
+		}
+		status := "attach " + msg.s.Name + ": " + msg.err.Error()
+		var exitErr *exec.ExitError
+		if errors.As(msg.err, &exitErr) && exitErr.ExitCode() != 255 && time.Since(m.attachStart) < 15*time.Second {
+			// the remote bootstrap-marker guard exits 1 fast when setup is
+			// still running — point at the log instead of a bare exit status
+			status += " — it may still be setting up; l shows the setup log"
+		}
+		m.attachSess, m.attachRetried = driver.Session{}, false
+		m.loading = true
+		m.status, m.statusBad = status, true
+		return m, tea.Batch(m.fetch, tickCmd()) // the refreshed state often explains it
+	case reachableMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.attachSess, m.attachRetried = driver.Session{}, false
+			m.status, m.statusBad = msg.err.Error(), true
+			return m, nil
+		}
+		return m.startAttach(msg.s) // second and final attempt; attachRetried stays set
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		if m.mode == modeLogs {
@@ -275,17 +335,31 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.cursor++
 		}
 	case "enter":
-		if len(m.sessions) > 0 {
-			if s := m.sessions[m.cursor]; s.State == driver.StateCreating {
-				m.status, m.statusBad = s.Name+" is still setting up — attach when it shows running", false
-				return m, nil
-			} else if s.State == driver.StateDeleting {
-				m.status, m.statusBad = s.Name+" is being deleted", false
+		if len(m.sessions) == 0 || m.opts.Attach == nil || m.attachSess.Name != "" {
+			return m, nil
+		}
+		s := m.sessions[m.cursor]
+		switch s.State {
+		case driver.StateCreating:
+			m.status, m.statusBad = s.Name+" is still setting up — attach when it shows running", false
+			return m, nil
+		case driver.StateDeleting:
+			m.status, m.statusBad = s.Name+" is being deleted", false
+			return m, nil
+		case driver.StateDead:
+			m.status, m.statusBad = s.Name+" is dead — no VM to attach to", false
+			return m, nil
+		case driver.StateParked:
+			if m.opts.Resume == nil {
+				m.status, m.statusBad = s.Name+" is parked — pier attach "+s.Name+" resumes it", false
 				return m, nil
 			}
-			m.action = Action{Kind: ActionAttach, Session: m.sessions[m.cursor]}
-			return m, tea.Quit
+			m.attachSess, m.loading = s, true
+			m.status, m.statusBad = "resuming "+s.Name+" (~20-60s)…", false
+			resume := m.opts.Resume
+			return m, tea.Batch(tickCmd(), func() tea.Msg { return resumedMsg{s, resume(s)} })
 		}
+		return m.startAttach(s)
 	case "l":
 		if len(m.sessions) > 0 && m.opts.FetchLog != nil {
 			s := m.sessions[m.cursor]
@@ -370,6 +444,21 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.fetch, tickCmd())
 	}
 	return m, nil
+}
+
+// startAttach hands the terminal to ssh via tea.ExecProcess: bubbletea leaves
+// the alt screen, restores the shell termios, runs the command, then restores
+// the TUI and delivers attachDoneMsg — a tmux detach lands back on this list.
+func (m model) startAttach(s driver.Session) (tea.Model, tea.Cmd) {
+	cmd, err := m.opts.Attach(s)
+	if err != nil {
+		m.attachSess, m.loading = driver.Session{}, false
+		m.status, m.statusBad = err.Error(), true
+		return m, nil
+	}
+	m.attachSess, m.attachStart, m.loading = s, time.Now(), false
+	m.status, m.statusBad = "attaching to "+s.Name+" — detach with C-b d (session keeps running)", false
+	return m, tea.ExecProcess(cmd, func(err error) tea.Msg { return attachDoneMsg{s, err} })
 }
 
 func (m model) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -460,9 +549,9 @@ func (m model) updateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.input == "" {
 			return m, nil
 		}
-		if m.opts.CreateDetached == nil { // legacy: quit, create in foreground
-			m.action = Action{Kind: ActionNew, Branch: m.input}
-			return m, tea.Quit
+		if m.opts.CreateDetached == nil { // no creator wired (tests)
+			m.mode = modeList
+			return m, nil
 		}
 		for _, s := range m.sessions {
 			if s.Name == m.input {
@@ -628,9 +717,34 @@ func (m model) settingsView() string {
 	return b.String()
 }
 
+// listRows is the table's row budget: terminal height minus every non-row
+// line View emits in the current mode, so the footer never clips off the
+// alternate screen (the renderer keeps the LAST height lines on overflow).
+func (m model) listRows() int {
+	if m.height == 0 { // no WindowSizeMsg yet (tests) — render everything
+		return len(m.sessions)
+	}
+	chrome := 6 // top margin+title+blank, column header, blank after table, trailing newline
+	switch m.mode {
+	case modeNew:
+		chrome += 5 // label + 3-line box + keys
+	case modeConfirm:
+		chrome++
+	case modeResize:
+		chrome += 2 + len(m.machines) // label + machine rows + keys
+	default:
+		chrome++ // keys
+		if m.status != "" {
+			chrome++
+		}
+	}
+	return max(3, m.height-chrome)
+}
+
 // table renders the session rows: dim column header, accent cursor, states
 // color-coded. Cells are padded as plain text first, then styled — ANSI
-// escapes would defeat %-*s width math.
+// escapes would defeat %-*s width math. When the terminal is shorter than
+// the list, a cursor-centered window of rows renders instead.
 func (m model) table() string {
 	nameW, repoW, stateW := 4, 4, 5
 	states := make([]string, len(m.sessions))
@@ -644,7 +758,13 @@ func (m model) table() string {
 	var b strings.Builder
 	b.WriteString(ui.Dim.Render(fmt.Sprintf("   %-*s  %-*s  %-*s  %-4s  %s",
 		nameW, "NAME", repoW, "REPO", stateW, "STATE", "AGE", "COST")) + "\n")
-	for i, s := range m.sessions {
+	rows, lo := m.listRows(), 0
+	if rows < len(m.sessions) {
+		lo = min(max(0, m.cursor-rows/2), len(m.sessions)-rows)
+	}
+	hi := min(len(m.sessions), lo+rows)
+	for i := lo; i < hi; i++ {
+		s := m.sessions[i]
 		marker := "   "
 		name := fmt.Sprintf("%-*s", nameW, s.Name)
 		if i == m.cursor {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,6 +1,9 @@
 package tui
 
 import (
+	"errors"
+	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -131,20 +134,25 @@ func TestResizePicker(t *testing.T) {
 	}
 }
 
-// Enter on a still-creating session must not leave the TUI to spawn ssh —
-// mid-create attaches used to dump a raw TargetNotConnected. It shows a
-// notice and stays put instead.
+// Enter on a still-creating session must not spawn ssh — mid-create attaches
+// used to dump a raw TargetNotConnected. It shows a notice and stays put
+// instead.
 func TestEnterOnCreatingSession(t *testing.T) {
-	m := model{loaded: true, sessions: []driver.Session{
-		{Name: "half-built", Repo: "myapp", State: driver.StateCreating},
-	}}
+	m := model{loaded: true,
+		opts: Options{Attach: func(driver.Session) (*exec.Cmd, error) {
+			t.Fatal("attach spawned for a creating session")
+			return nil, nil
+		}},
+		sessions: []driver.Session{
+			{Name: "half-built", Repo: "myapp", State: driver.StateCreating},
+		}}
 	got, cmd := m.updateList(tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd != nil {
-		t.Fatal("enter on a creating session must not quit to attach")
+		t.Fatal("enter on a creating session must not attach")
 	}
 	gm := got.(model)
-	if gm.action.Kind == ActionAttach {
-		t.Error("attach action set for a creating session")
+	if gm.attachSess.Name != "" {
+		t.Error("attach in flight for a creating session")
 	}
 	if !strings.Contains(gm.status, "still setting up") || gm.statusBad {
 		t.Errorf("want a friendly notice, got status=%q bad=%v", gm.status, gm.statusBad)
@@ -186,9 +194,6 @@ func TestLogsKey(t *testing.T) {
 	if gm.mode != modeLogs || gm.logSess.Name != "half-built" {
 		t.Errorf("want modeLogs on half-built, got mode=%v session=%q", gm.mode, gm.logSess.Name)
 	}
-	if gm.action.Kind != ActionNone {
-		t.Errorf("the viewer must stay inside the TUI, got action %v", gm.action.Kind)
-	}
 	if !gm.logStick || !gm.logLoading {
 		t.Errorf("the viewer must open following the tail while it fetches, got stick=%v loading=%v", gm.logStick, gm.logLoading)
 	}
@@ -198,6 +203,194 @@ func TestLogsKey(t *testing.T) {
 	gm = got.(model)
 	if gm.mode != modeList || len(gm.sessions) != 1 {
 		t.Errorf("esc must return to the list, got mode=%v sessions=%d", gm.mode, len(gm.sessions))
+	}
+}
+
+// Enter on a running session hands the terminal to ssh via ExecProcess —
+// the TUI must survive the attach (no tea.Quit), so a detach lands back on
+// the list.
+func TestEnterAttachesWithoutQuitting(t *testing.T) {
+	attached := 0
+	m := model{loaded: true,
+		opts: Options{Attach: func(driver.Session) (*exec.Cmd, error) {
+			attached++
+			return exec.Command("true"), nil
+		}},
+		sessions: []driver.Session{
+			{Name: "fix-auth", Repo: "myapp", State: driver.StateRunning},
+		}}
+	got, cmd := m.updateList(tea.KeyMsg{Type: tea.KeyEnter})
+	gm := got.(model)
+	if attached != 1 || cmd == nil {
+		t.Fatalf("enter must build and run the attach command, got attached=%d cmd=%v", attached, cmd)
+	}
+	if _, quit := cmd().(tea.QuitMsg); quit {
+		t.Error("enter must not quit the TUI to attach")
+	}
+	if gm.attachSess.Name != "fix-auth" {
+		t.Errorf("attachSess must mark the attach in flight, got %q", gm.attachSess.Name)
+	}
+	if !strings.Contains(gm.status, "C-b d") {
+		t.Errorf("the detach hint must show in the TUI, got status=%q", gm.status)
+	}
+
+	// A second enter while the attach is in flight is a no-op.
+	if _, cmd := gm.updateList(tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil || attached != 1 {
+		t.Errorf("enter during an attach must do nothing, got attached=%d", attached)
+	}
+}
+
+// Enter on a parked session resumes it inside the TUI first, then attaches;
+// a failed resume clears the in-flight state with an error status.
+func TestEnterOnParkedResumesFirst(t *testing.T) {
+	resumed, attached := 0, 0
+	m := model{loaded: true,
+		opts: Options{
+			Resume: func(driver.Session) error { resumed++; return nil },
+			Attach: func(driver.Session) (*exec.Cmd, error) {
+				attached++
+				return exec.Command("true"), nil
+			},
+		},
+		sessions: []driver.Session{
+			{Name: "fix-auth", Repo: "myapp", State: driver.StateParked},
+		}}
+	got, cmd := m.updateList(tea.KeyMsg{Type: tea.KeyEnter})
+	gm := got.(model)
+	if attached != 0 || !strings.Contains(gm.status, "resuming") || !gm.loading {
+		t.Fatalf("enter on parked must resume before attaching, got attached=%d status=%q", attached, gm.status)
+	}
+	var rm tea.Msg
+	if batch, ok := cmd().(tea.BatchMsg); ok { // Batch wraps, doesn't run
+		for _, c := range batch {
+			if msg, ok := c().(resumedMsg); ok {
+				rm = msg
+			}
+		}
+	}
+	if resumed != 1 || rm == nil {
+		t.Fatalf("the batch must run the resume, got resumed=%d msg=%v", resumed, rm)
+	}
+	got, cmd = gm.Update(rm)
+	gm = got.(model)
+	if attached != 1 || cmd == nil || gm.attachSess.Name != "fix-auth" {
+		t.Errorf("a finished resume must attach, got attached=%d cmd=%v sess=%q", attached, cmd, gm.attachSess.Name)
+	}
+
+	// A failed resume surfaces the error and clears the in-flight state.
+	got, _ = gm.Update(resumedMsg{gm.attachSess, errors.New("quota exceeded")})
+	gm = got.(model)
+	if !gm.statusBad || gm.attachSess.Name != "" {
+		t.Errorf("a failed resume must error and clear the attach, got status=%q sess=%q", gm.status, gm.attachSess.Name)
+	}
+}
+
+// A fast transport failure gets exactly one wait-for-reachability and retry,
+// mirroring the CLI attach loop; a second failure lands an error on the list.
+func TestAttachRetriesOnceThenFails(t *testing.T) {
+	waited, attached := 0, 0
+	s := driver.Session{Name: "fix-auth", Repo: "myapp", State: driver.StateRunning}
+	m := model{loaded: true, sessions: []driver.Session{s},
+		attachSess: s, attachStart: time.Now(),
+		opts: Options{
+			Fetch:         func() ([]driver.Session, error) { return nil, nil },
+			RetryAttach:   func(error, time.Duration) bool { return true },
+			WaitReachable: func(driver.Session) error { waited++; return nil },
+			Attach: func(driver.Session) (*exec.Cmd, error) {
+				attached++
+				return exec.Command("true"), nil
+			},
+		}}
+	got, cmd := m.Update(attachDoneMsg{s, errors.New("exit status 255")})
+	gm := got.(model)
+	if !gm.attachRetried || !strings.Contains(gm.status, "not reachable yet") {
+		t.Fatalf("a retryable failure must wait for reachability, got status=%q", gm.status)
+	}
+	var rm tea.Msg
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if msg, ok := c().(reachableMsg); ok {
+				rm = msg
+			}
+		}
+	}
+	if waited != 1 || rm == nil {
+		t.Fatalf("the batch must run the reachability wait, got waited=%d msg=%v", waited, rm)
+	}
+	got, cmd = gm.Update(rm)
+	gm = got.(model)
+	if attached != 1 || cmd == nil {
+		t.Fatalf("a reachable session must attach again, got attached=%d cmd=%v", attached, cmd)
+	}
+
+	// The second failure is final: error status, no more waits.
+	got, _ = gm.Update(attachDoneMsg{s, errors.New("exit status 255")})
+	gm = got.(model)
+	if !gm.statusBad || gm.attachSess.Name != "" || waited != 1 {
+		t.Errorf("a second failure must give up, got status=%q sess=%q waited=%d", gm.status, gm.attachSess.Name, waited)
+	}
+}
+
+// Detaching (ssh exiting 0) lands back on the list with a notice and a
+// fresh session fetch — never at the shell.
+func TestDetachReturnsToList(t *testing.T) {
+	s := driver.Session{Name: "fix-auth", Repo: "myapp", State: driver.StateRunning}
+	m := model{loaded: true, sessions: []driver.Session{s}, attachSess: s,
+		opts: Options{Fetch: func() ([]driver.Session, error) { return []driver.Session{s}, nil }}}
+	got, cmd := m.Update(attachDoneMsg{s, nil})
+	gm := got.(model)
+	if !strings.Contains(gm.status, "detached from fix-auth") || gm.statusBad {
+		t.Errorf("want a detach notice, got status=%q bad=%v", gm.status, gm.statusBad)
+	}
+	if gm.attachSess.Name != "" {
+		t.Errorf("the attach must no longer be in flight, got %q", gm.attachSess.Name)
+	}
+	fetched := false
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if _, ok := c().(sessionsMsg); ok {
+				fetched = true
+			}
+		}
+	}
+	if !fetched {
+		t.Error("a detach must refresh the session list")
+	}
+}
+
+// On the alternate screen the renderer keeps the LAST height lines when the
+// view overflows, which would scroll the header off — the table must window
+// its rows around the cursor instead.
+func TestTableWindowFollowsCursor(t *testing.T) {
+	m := model{loaded: true, height: 15}
+	for i := range 40 {
+		m.sessions = append(m.sessions, driver.Session{
+			Name: fmt.Sprintf("s%d", i), Repo: "myapp", State: driver.StateRunning,
+		})
+	}
+
+	v := m.View()
+	if !strings.Contains(v, "s0") || strings.Contains(v, "s39") {
+		t.Errorf("cursor at the top must show the first rows:\n%s", v)
+	}
+	if c := strings.Count(v, "\n"); c > m.height {
+		t.Errorf("view is %d lines for a %d-line terminal:\n%s", c, m.height, v)
+	}
+	if !strings.Contains(v, "NAME") || !strings.Contains(v, "quit") {
+		t.Errorf("header and footer must survive the windowing:\n%s", v)
+	}
+
+	m.cursor = 39
+	v = m.View()
+	if !strings.Contains(v, "s39") || strings.Contains(v, "s0 ") {
+		t.Errorf("the window must follow the cursor to the bottom:\n%s", v)
+	}
+
+	// No WindowSizeMsg yet (height 0): render everything, as inline tests do.
+	m.height, m.cursor = 0, 0
+	v = m.View()
+	if !strings.Contains(v, "s0") || !strings.Contains(v, "s39") {
+		t.Errorf("zero height must render all rows:\n%s", v)
 	}
 }
 


### PR DESCRIPTION
## What

Makes the bare `pier` TUI a full-screen app and keeps the user inside it across attaches.

- **Alternate screen buffer** (`tea.WithAltScreen()`): shell scrollback is hidden while pier runs and restored untouched on quit — no TUI residue.
- **Detach returns to the homepage**: attach no longer quits the TUI. The terminal is handed to ssh via `tea.ExecProcess`, so a tmux `C-b d` (or exiting tmux) lands back on the session list with a "detached from X" notice and a fresh fetch.
- The attach flow moved into the TUI as a small state machine mirroring the CLI: parked sessions show an in-place "resuming (~20-60s)…" spinner first, a fast transport failure gets the same single bounded wait-and-retry, and the `C-b d` hint moved from a println into the TUI status.
- The session table renders a cursor-following window of rows when the list is taller than the terminal, so the header and key footer never clip off the alt screen.
- The `Action`/`ActionAttach`/`ActionNew` quit-then-act mechanism is deleted; `cmdTUI` passes `Attach`/`Resume`/`RetryAttach`/`WaitReachable` closures instead.

## Scope kept

- `pier ls`, `pier logs`, etc. stay plain stdout and pipeable.
- CLI attaches (`pier attach <id>`, `pier <branch>`) still exit to the shell on detach; `attach()`/`retryAttach()`/`waitReachable()`/`resumeIfParked()` in main are unchanged.

## Tests

Two tests updated for the removed Action type; five added: attach-without-quitting, parked-resume-then-attach, single bounded retry, detach-returns-to-list, cursor-following table window. `go vet`, `go test ./...`, `gofmt` clean. Verified manually: full-screen open/quit restores scrollback, attach → `C-b d` → back on the list.