### PR TITLE
tui: redesign the settings page

### DIFF
--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -950,6 +950,15 @@ func cmdTUI() {
 		Machines: func(s driver.Session) []driver.Machine {
 			return drv.Machines(s.InstanceType)
 		},
+		// The settings machine picker serves whichever field is selected, so it
+		// reads the catalog by driver id — not the active driver's — since a
+		// user on AWS may still edit the gcp machine default.
+		SettingsMachines: func(driverID, currentType string) []driver.Machine {
+			if driverID == "gcp-gce" {
+				return gcpgce.Machines(currentType)
+			}
+			return awsec2.Machines(currentType)
+		},
 		CreateDetached: spawnCreate,
 		FetchLog: func(s driver.Session) (string, error) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,28 +173,166 @@ func ParkDuration(s string) (time.Duration, error) {
 	return time.ParseDuration(s)
 }
 
-// Setting is one field the TUI settings page can edit.
-type Setting struct {
-	Key  string
-	Hint string
+// FieldKind tells the settings UI how to edit a field.
+type FieldKind int
+
+const (
+	KindText    FieldKind = iota // free-text editor
+	KindChoice                   // pick from the fixed Options list
+	KindMachine                  // pick from the driver's machine catalog (injected)
+)
+
+// Option is one choice in a KindChoice picker. Value is what Set receives;
+// Label is what the picker shows (falls back to Value); Desc is a dim
+// right-column annotation (a human region name, machine specs, guidance).
+type Option struct {
+	Value string
+	Label string
+	Desc  string
 }
 
-// Settings lists the settable keys in display order. Secrets and baked AMIs
-// are deliberately absent: those are managed by `pier setup` and `pier bake`.
-var Settings = []Setting{
-	{"driver", ""},
-	{"idle_timeout", "detached and quiet this long → park"},
-	{"unattended_cap", "parks even while busy"},
-	{"aws.profile", ""},
-	{"aws.region", ""},
-	{"aws.instance_type", "machine for new sessions"},
-	{"aws.disk_gib", ""},
-	{"aws.subnet", "optional"},
-	{"aws.direct", "ssh straight to the VM, fast — false forces the ssm tunnel"},
-	{"gcp.project", ""},
-	{"gcp.zone", ""},
-	{"gcp.machine_type", "machine for new sessions"},
-	{"gcp.disk_gib", ""},
+// Field is one editable setting: how it's grouped, labeled, and explained,
+// how it's edited (Kind + Options), and how its value reads back (Empty /
+// Suffix). Validation always runs through Set, the single write path.
+type Field struct {
+	Key      string
+	Group    string // "session", "aws", "gcp"
+	Label    string // human label shown on the row
+	Hint     string // short one-liner beside the value
+	Detail   string // multi-line (\n-split) footer for the selected field
+	Default  string // shown in the footer; "" prints nothing
+	Kind     FieldKind
+	Options  []Option // KindChoice choices; nil otherwise
+	NoCustom bool     // a closed enum: the picker offers no "custom…" escape
+	Empty    string   // placeholder for an empty value ("" → "(unset)")
+	Suffix   string   // appended to a raw value on display (e.g. " GiB")
+}
+
+// Display renders a stored value for humans: choice labels instead of raw
+// values, a placeholder when empty, a unit suffix otherwise. Storage is
+// untouched — this is presentation only.
+func (f Field) Display(v string) string {
+	if v == "" {
+		if f.Empty != "" {
+			return f.Empty
+		}
+		return "(unset)"
+	}
+	if f.Kind == KindChoice {
+		for _, o := range f.Options {
+			if o.Value == v {
+				if o.Label != "" {
+					return o.Label
+				}
+				return o.Value
+			}
+		}
+	}
+	return v + f.Suffix
+}
+
+// durationOpts / diskOpts are shared so the aws and gcp groups read the same.
+var (
+	idleOpts = []Option{{Value: "15m"}, {Value: "30m"}, {Value: "1h"}, {Value: "2h"}, {Value: "never"}}
+	capOpts  = []Option{{Value: "4h"}, {Value: "8h"}, {Value: "24h"}, {Value: "never"}}
+	diskOpts = []Option{{Value: "20", Label: "20 GiB"}, {Value: "40", Label: "40 GiB"}, {Value: "80", Label: "80 GiB"}, {Value: "160", Label: "160 GiB"}}
+)
+
+// Settings lists the settable fields in display order, grouped session → aws →
+// gcp. Secrets and baked images are deliberately absent: those are managed by
+// `pier setup` and `pier bake`, and the TUI shows them read-only.
+var Settings = []Field{
+	{
+		Key: "driver", Group: "session", Label: "cloud", Hint: "runs new sessions",
+		Kind: KindChoice, NoCustom: true, Default: "aws-ec2",
+		Options: []Option{
+			{Value: "aws-ec2", Label: "AWS EC2", Desc: "Amazon EC2 · direct ssh or SSM"},
+			{Value: "gcp-gce", Label: "GCP Compute Engine", Desc: "Google Compute Engine · IAP tunnel"},
+		},
+		Detail: "Which provider runs new sessions.\nExisting sessions stay on the cloud they were built on; the other cloud's settings wait dimmed below until you switch.",
+	},
+	{
+		Key: "idle_timeout", Group: "session", Label: "auto-park", Hint: "park when detached & quiet",
+		Kind: KindChoice, Options: idleOpts, Default: "30m",
+		Detail: "A session detached and quiet this long parks itself: the VM stops, the disk stays (~$3-4/mo), and attaching resumes it in ~20-60s.\n`pier keep` exempts one session; --idle overrides one create.\nformat: 30m, 2h, or never",
+	},
+	{
+		Key: "unattended_cap", Group: "session", Label: "unattended cap", Hint: "park even mid-run",
+		Kind: KindChoice, Options: capOpts, Default: "8h",
+		Detail: "Parks a session even while the agent is still busy, once you've been detached this long — a runaway loop can't burn compute for days.\n--cap overrides one create.\nformat: 8h or never",
+	},
+	{
+		Key: "aws.profile", Group: "aws", Label: "profile", Hint: "AWS CLI profile for every call",
+		Kind:   KindText,
+		Detail: "The AWS CLI profile every pier command runs under — SSO, MFA, and its default region all come from it.\nset one up with `aws configure`.",
+	},
+	{
+		Key: "aws.region", Group: "aws", Label: "region", Hint: "where new VMs launch",
+		Kind: KindChoice, Default: "eu-central-1",
+		Options: []Option{
+			{Value: "us-east-1", Desc: "N. Virginia"},
+			{Value: "us-east-2", Desc: "Ohio"},
+			{Value: "us-west-2", Desc: "Oregon"},
+			{Value: "eu-west-1", Desc: "Ireland"},
+			{Value: "eu-central-1", Desc: "Frankfurt"},
+			{Value: "ap-south-1", Desc: "Mumbai"},
+			{Value: "ap-southeast-1", Desc: "Singapore"},
+			{Value: "ap-northeast-1", Desc: "Tokyo"},
+		},
+		Detail: "New session VMs launch here; existing sessions stay where they are.\nafter switching, `pier doctor` checks the groundwork exists in the new region.\nformat: us-east-1, eu-central-1, …",
+	},
+	{
+		Key: "aws.instance_type", Group: "aws", Label: "machine", Hint: "default VM for new sessions",
+		Kind: KindMachine, Default: "t4g.medium",
+		Detail: "New sessions start on this VM type. Undersize freely — `m` resizes any live session in about a minute, disk intact.",
+	},
+	{
+		Key: "aws.disk_gib", Group: "aws", Label: "disk", Hint: "per-session root disk",
+		Kind: KindChoice, Options: diskOpts, Suffix: " GiB", Default: "40",
+		Detail: "Root disk for each new session — it's what survives parking and what a parked session costs (~$3-4/mo).\nwhole GiB, at least 8",
+	},
+	{
+		Key: "aws.direct", Group: "aws", Label: "connection", Hint: "how ssh reaches the VM",
+		Kind: KindChoice, NoCustom: true, Default: "direct ssh",
+		Options: []Option{
+			{Value: "true", Label: "direct ssh", Desc: "straight to the VM's public IP — full speed"},
+			{Value: "false", Label: "SSM tunnel", Desc: "everything through SSM (~1 MB/s)"},
+		},
+		Detail: "How the terminal reaches the VM.\ndirect ssh dials the public IP (full speed), opens TCP 22 to your current IP only, and falls back to the SSM tunnel by itself when that's blocked.\nSSM tunnel forces the tunnel — for networks that block outbound 22 or orgs that disallow the ingress calls.",
+	},
+	{
+		Key: "aws.subnet", Group: "aws", Label: "subnet", Hint: "only without a default VPC",
+		Kind: KindText, Empty: "(default VPC)",
+		Detail: "Only for accounts whose default VPC was deleted: session VMs launch in this subnet. Leave empty otherwise.\nformat: subnet-0abc123…",
+	},
+	{
+		Key: "gcp.project", Group: "gcp", Label: "project", Hint: "project sessions are created in",
+		Kind:   KindText,
+		Detail: "Sessions are created in this project — pier always passes it explicitly, never your active gcloud default. Required when cloud is GCP.",
+	},
+	{
+		Key: "gcp.zone", Group: "gcp", Label: "zone", Hint: "where new VMs launch",
+		Kind: KindChoice, Default: "europe-west3-a",
+		Options: []Option{
+			{Value: "us-central1-a", Desc: "Iowa"},
+			{Value: "us-east1-b", Desc: "S. Carolina"},
+			{Value: "europe-west1-b", Desc: "Belgium"},
+			{Value: "europe-west3-a", Desc: "Frankfurt"},
+			{Value: "europe-west4-a", Desc: "Netherlands"},
+			{Value: "asia-southeast1-a", Desc: "Singapore"},
+		},
+		Detail: "New session VMs launch in this zone; existing sessions stay put.\nformat: europe-west3-a, us-central1-a, …",
+	},
+	{
+		Key: "gcp.machine_type", Group: "gcp", Label: "machine", Hint: "default VM for new sessions",
+		Kind: KindMachine, Default: "e2-medium",
+		Detail: "New sessions start on this machine type. Undersize freely — `m` resizes any live session in a couple of minutes, disk intact.",
+	},
+	{
+		Key: "gcp.disk_gib", Group: "gcp", Label: "disk", Hint: "per-session boot disk",
+		Kind: KindChoice, Options: diskOpts, Suffix: " GiB", Default: "40",
+		Detail: "Boot disk for each new session — it's what survives parking and what a parked session costs (~$3-4/mo).\nwhole GiB, at least 10",
+	},
 }
 
 // Get returns the current value of a settable key ("" for unknown keys).
@@ -230,15 +368,30 @@ func Get(c Config, key string) string {
 	return ""
 }
 
-// Set mutates one whitelisted scalar, validating durations and disk size.
-// Changes apply to new sessions only.
+// Set mutates one whitelisted scalar, validating it before it lands. A
+// rejected value never touches the config, so the caller can keep the field
+// open for a fix. Changes apply to new sessions only.
 func Set(c *Config, key, val string) error {
 	switch key {
 	case "driver":
-		c.Driver = val
+		// Strict: a typo like "gcp" used to save and then silently fall back to
+		// the AWS driver at create time. Common aliases normalize; the rest is
+		// a hard error here, not a surprise minutes later.
+		switch strings.ToLower(strings.TrimSpace(val)) {
+		case "aws-ec2", "aws", "ec2":
+			c.Driver = "aws-ec2"
+		case "gcp-gce", "gcp", "gce", "google":
+			c.Driver = "gcp-gce"
+		default:
+			return fmt.Errorf("driver: want aws-ec2 or gcp-gce (got %q)", val)
+		}
 	case "idle_timeout", "unattended_cap":
-		if _, err := ParkDuration(val); err != nil {
+		d, err := ParkDuration(val)
+		if err != nil {
 			return fmt.Errorf("%s: %v (want a duration like 30m or 8h, or never)", key, err)
+		}
+		if d < 0 {
+			return fmt.Errorf("%s: must not be negative (got %q)", key, val)
 		}
 		if key == "idle_timeout" {
 			c.IdleTimeout = val
@@ -246,33 +399,57 @@ func Set(c *Config, key, val string) error {
 			c.UnattendedCap = val
 		}
 	case "aws.profile":
-		c.AWS.Profile = val
+		c.AWS.Profile = strings.TrimSpace(val)
 	case "aws.region":
+		val = strings.TrimSpace(val)
+		if !validRegionish(val) {
+			return fmt.Errorf("aws.region: want a region like us-east-1 or eu-central-1 (got %q)", val)
+		}
 		c.AWS.Region = val
 	case "aws.instance_type":
+		val = strings.TrimSpace(val)
+		if !validAWSType(val) {
+			return fmt.Errorf("aws.instance_type: want a type like t4g.medium (got %q)", val)
+		}
 		c.AWS.InstanceType = val
 	case "aws.disk_gib":
-		n, err := strconv.Atoi(val)
+		n, err := strconv.Atoi(strings.TrimSpace(val))
 		if err != nil || n < 8 {
 			return fmt.Errorf("aws.disk_gib: want a whole number of GiB, at least 8 (got %q)", val)
 		}
 		c.AWS.DiskGiB = n
 	case "aws.subnet":
+		val = strings.TrimSpace(val)
+		if val != "" && !strings.HasPrefix(val, "subnet-") {
+			return fmt.Errorf("aws.subnet: want a subnet id like subnet-0abc123, or empty for the default VPC (got %q)", val)
+		}
 		c.AWS.Subnet = val
 	case "gcp.project":
+		val = strings.TrimSpace(val)
+		if val != "" && !validProjectID(val) {
+			return fmt.Errorf("gcp.project: want a project id — lowercase letters, digits, hyphens, 6-30 chars (got %q)", val)
+		}
 		c.GCP.Project = val
 	case "gcp.zone":
+		val = strings.TrimSpace(val)
+		if !validRegionish(val) {
+			return fmt.Errorf("gcp.zone: want a zone like europe-west3-a or us-central1-a (got %q)", val)
+		}
 		c.GCP.Zone = val
 	case "gcp.machine_type":
+		val = strings.TrimSpace(val)
+		if !validGCPType(val) {
+			return fmt.Errorf("gcp.machine_type: want a type like e2-medium or e2-standard-4 (got %q)", val)
+		}
 		c.GCP.MachineType = val
 	case "gcp.disk_gib":
-		n, err := strconv.Atoi(val)
+		n, err := strconv.Atoi(strings.TrimSpace(val))
 		if err != nil || n < 10 {
 			return fmt.Errorf("gcp.disk_gib: want a whole number of GiB, at least 10 (got %q)", val)
 		}
 		c.GCP.DiskGiB = n
 	case "aws.direct":
-		switch strings.ToLower(val) {
+		switch strings.ToLower(strings.TrimSpace(val)) {
 		case "true", "yes", "on":
 			c.AWS.Direct = true
 		case "false", "no", "off":
@@ -288,4 +465,71 @@ func Set(c *Config, key, val string) error {
 		return fmt.Errorf("unknown key %q — settable: %s", key, strings.Join(keys, ", "))
 	}
 	return nil
+}
+
+// validRegionish is a lenient guard for AWS regions and GCP zones: a lowercase
+// token with a hyphen and a digit (us-east-1, europe-west3-a, us-gov-west-1).
+// Deliberately loose — it catches spaces, capitals, and wrong-field typos
+// without rejecting valid or future names the strict picker doesn't list.
+func validRegionish(s string) bool {
+	if s == "" || !strings.Contains(s, "-") {
+		return false
+	}
+	hasDigit := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r == '-':
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		default:
+			return false
+		}
+	}
+	return hasDigit
+}
+
+// validAWSType matches a family.size token (t4g.medium, m7g.4xlarge).
+func validAWSType(s string) bool {
+	fam, size, ok := strings.Cut(s, ".")
+	return ok && lowerAlnum(fam) && lowerAlnum(size)
+}
+
+// validGCPType matches a hyphenated machine type (e2-medium, e2-standard-4,
+// e2-custom-4-8192).
+func validGCPType(s string) bool {
+	if s == "" || s[0] < 'a' || s[0] > 'z' || !strings.Contains(s, "-") {
+		return false
+	}
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+// validProjectID is the shape of a GCP project id: 6-30 chars, starts with a
+// letter, lowercase letters/digits/hyphens, no trailing hyphen.
+func validProjectID(s string) bool {
+	if len(s) < 6 || len(s) > 30 || s[0] < 'a' || s[0] > 'z' || strings.HasSuffix(s, "-") {
+		return false
+	}
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+func lowerAlnum(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/config/set_test.go
+++ b/internal/config/set_test.go
@@ -80,3 +80,55 @@ func TestSet(t *testing.T) {
 		}
 	}
 }
+
+// TestSetValidation covers the hardened validators added with the settings
+// redesign: a bad value must be rejected here, at Set, not silently swallowed
+// to fail minutes later at create time.
+func TestSetValidation(t *testing.T) {
+	cfg := Default()
+
+	// driver used to accept anything and then fall back to AWS. Aliases
+	// normalize; garbage is a hard error.
+	if err := Set(&cfg, "driver", "gcp"); err != nil || cfg.Driver != "gcp-gce" {
+		t.Errorf("driver alias gcp must normalize to gcp-gce, got %q err=%v", cfg.Driver, err)
+	}
+	if err := Set(&cfg, "driver", "azure"); err == nil {
+		t.Error("an unknown driver must be rejected, not saved and silently downgraded")
+	}
+	cfg.Driver = "aws-ec2"
+
+	// A negative duration parses but is nonsense.
+	if err := Set(&cfg, "idle_timeout", "-5m"); err == nil {
+		t.Error("a negative idle_timeout must be rejected")
+	}
+
+	for _, c := range []struct {
+		key, val string
+		ok       bool
+	}{
+		{"aws.region", "eu-central-1", true},
+		{"aws.region", "US-EAST-1", false}, // uppercase
+		{"aws.region", "us east 1", false}, // spaces
+		{"aws.region", "region", false},    // no digit
+		{"aws.instance_type", "m7g.4xlarge", true},
+		{"aws.instance_type", "not a type", false},
+		{"aws.subnet", "subnet-0abc123", true},
+		{"aws.subnet", "", true}, // empty = default VPC
+		{"aws.subnet", "vpc-123", false},
+		{"gcp.zone", "us-central1-a", true},
+		{"gcp.zone", "europe west3 a", false},
+		{"gcp.machine_type", "e2-standard-4", true},
+		{"gcp.machine_type", "E2-medium", false}, // uppercase
+		{"gcp.project", "valid-project-1", true},
+		{"gcp.project", "no", false}, // too short
+		{"gcp.project", "Bad_Project", false},
+	} {
+		err := Set(&cfg, c.key, c.val)
+		if c.ok && err != nil {
+			t.Errorf("Set(%q, %q) should succeed, got %v", c.key, c.val, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("Set(%q, %q) should be rejected, but was accepted", c.key, c.val)
+		}
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
@@ -36,6 +37,10 @@ type Options struct {
 	// session so nobody memorizes type names. nil hides the key.
 	Resize   func(s driver.Session, instanceType string) error
 	Machines func(s driver.Session) []driver.Machine
+	// SettingsMachines is the machine catalog for the settings machine picker,
+	// given a driver id ("aws-ec2"/"gcp-gce") and the currently configured
+	// type. nil falls the machine fields back to free-text editing.
+	SettingsMachines func(driverID, currentType string) []driver.Machine
 	// FetchLog returns a session's setup log for the l key's in-place viewer.
 	// nil hides the key.
 	FetchLog func(s driver.Session) (string, error)
@@ -87,9 +92,13 @@ type model struct {
 	attachRetried bool           // one bounded reconnect per attach, like the CLI
 	// settings page state; cfg loads fresh each time s opens the page
 	cfg      *config.Config
-	setIdx   int
-	editing  bool
+	setIdx   int  // index into config.Settings (the selected field)
+	editing  bool // free-text editor open for the selected field
 	setInput string
+	// settings picker sub-state: a choice/machine field's dropdown
+	picking  bool
+	pickOpts []config.Option // options shown (machine catalog converted in)
+	pickIdx  int
 	// resize picker state; machines reload each time m opens the picker
 	machines []driver.Machine
 	machIdx  int
@@ -437,7 +446,7 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status, m.statusBad = err.Error(), true
 			return m, nil
 		}
-		m.cfg, m.setIdx, m.editing = &cfg, 0, false
+		m.cfg, m.setIdx, m.editing, m.picking = &cfg, 0, false, false
 		m.mode = modeSettings
 	case "r":
 		m.loading = true
@@ -463,32 +472,10 @@ func (m model) startAttach(s driver.Session) (tea.Model, tea.Cmd) {
 
 func (m model) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.editing {
-		switch msg.String() {
-		case "esc", "ctrl+c":
-			m.editing = false
-			m.status = ""
-		case "enter":
-			key := config.Settings[m.setIdx].Key
-			if err := config.Set(m.cfg, key, m.setInput); err != nil {
-				m.status, m.statusBad = err.Error(), true
-				return m, nil // stay editing so the value can be fixed
-			}
-			if err := m.cfg.Save(); err != nil {
-				m.status, m.statusBad = err.Error(), true
-				return m, nil
-			}
-			m.editing = false
-			m.status, m.statusBad = key+" saved — applies to new sessions", false
-		case "backspace":
-			if len(m.setInput) > 0 {
-				m.setInput = m.setInput[:len(m.setInput)-1]
-			}
-		default:
-			if msg.Type == tea.KeyRunes && !strings.ContainsRune(string(msg.Runes), ' ') {
-				m.setInput += string(msg.Runes)
-			}
-		}
-		return m, nil
+		return m.updateSettingEdit(msg)
+	}
+	if m.picking {
+		return m.updateSettingPick(msg)
 	}
 	m.status = ""
 	switch msg.String() {
@@ -503,10 +490,122 @@ func (m model) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.setIdx++
 		}
 	case "enter":
-		m.editing = true
-		m.setInput = config.Get(*m.cfg, config.Settings[m.setIdx].Key)
+		return m.openSetting()
 	}
 	return m, nil
+}
+
+// openSetting opens the selected field for editing: a picker for choice and
+// machine fields, the free-text editor for the rest. A machine field with no
+// catalog wired (tests) falls back to the editor.
+func (m model) openSetting() (tea.Model, tea.Cmd) {
+	f := config.Settings[m.setIdx]
+	cur := config.Get(*m.cfg, f.Key)
+	switch f.Kind {
+	case config.KindChoice:
+		m.picking, m.pickOpts, m.pickIdx = true, f.Options, optIndex(f.Options, cur)
+	case config.KindMachine:
+		var cat []driver.Machine
+		if m.opts.SettingsMachines != nil {
+			cat = m.opts.SettingsMachines(driverID(f.Group), cur)
+		}
+		if len(cat) == 0 {
+			m.editing, m.setInput = true, cur
+			return m, nil
+		}
+		m.pickOpts = make([]config.Option, len(cat))
+		for i, mc := range cat {
+			m.pickOpts[i] = config.Option{Value: mc.Type, Desc: fmt.Sprintf("%2s vCPU · %3s GiB · %s", mc.CPU, mc.Mem, mc.Cost)}
+		}
+		m.picking, m.pickIdx = true, optIndex(m.pickOpts, cur)
+	default:
+		m.editing, m.setInput = true, cur
+	}
+	return m, nil
+}
+
+func (m model) updateSettingEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c":
+		m.editing, m.status = false, ""
+	case "enter":
+		return m.saveSetting(m.setInput)
+	case "backspace":
+		if len(m.setInput) > 0 {
+			m.setInput = m.setInput[:len(m.setInput)-1]
+		}
+	default:
+		if msg.Type == tea.KeyRunes && !strings.ContainsRune(string(msg.Runes), ' ') {
+			m.setInput += string(msg.Runes)
+		}
+	}
+	return m, nil
+}
+
+func (m model) updateSettingPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	f := config.Settings[m.setIdx]
+	last := len(m.pickOpts) // the "custom…" row sits one past the real options
+	if f.NoCustom {
+		last = len(m.pickOpts) - 1
+	}
+	switch msg.String() {
+	case "q", "esc", "ctrl+c":
+		m.picking, m.status = false, ""
+	case "up", "k":
+		if m.pickIdx > 0 {
+			m.pickIdx--
+		}
+	case "down", "j":
+		if m.pickIdx < last {
+			m.pickIdx++
+		}
+	case "enter":
+		if !f.NoCustom && m.pickIdx == len(m.pickOpts) { // custom… → free text
+			m.picking = false
+			m.editing, m.setInput = true, config.Get(*m.cfg, f.Key)
+			return m, nil
+		}
+		return m.saveSetting(m.pickOpts[m.pickIdx].Value)
+	}
+	return m, nil
+}
+
+// saveSetting validates val through config.Set (the single write path) and
+// persists it. A rejected value keeps the editor/picker open so it can be
+// fixed; the config on disk is never touched by a bad value.
+func (m model) saveSetting(val string) (tea.Model, tea.Cmd) {
+	f := config.Settings[m.setIdx]
+	if err := config.Set(m.cfg, f.Key, val); err != nil {
+		m.status, m.statusBad = err.Error(), true
+		return m, nil
+	}
+	if err := m.cfg.Save(); err != nil {
+		m.status, m.statusBad = err.Error(), true
+		return m, nil
+	}
+	m.editing, m.picking = false, false
+	m.status, m.statusBad = f.Label+" saved — applies to new sessions", false
+	return m, nil
+}
+
+// optIndex is the position of val in opts, or 0 (a custom value not in the
+// list simply lands the cursor on the first option).
+func optIndex(opts []config.Option, val string) int {
+	for i, o := range opts {
+		if o.Value == val {
+			return i
+		}
+	}
+	return 0
+}
+
+// driverID maps a settings group to the driver id whose machine catalog and
+// conventions it follows.
+func driverID(group string) string {
+	if group == "gcp" {
+		return "gcp-gce"
+	}
+	return "aws-ec2"
 }
 
 func (m model) updateResize(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -669,52 +768,284 @@ func (m model) View() string {
 	return b.String()
 }
 
-// settingsView is the s page: every settable config key with inline editing.
+// settingsView is the s page: fields grouped session → aws → gcp, the
+// inactive cloud dimmed but still editable, a detail footer for the selected
+// field, and a read-only section for what pier setup and pier bake manage.
 // Values save straight to config.toml and apply to new sessions.
 func (m model) settingsView() string {
-	var b strings.Builder
-	b.WriteString("\n " + ui.Title.Render("⚓ pier settings") + ui.Dim.Render("  "+config.Path()) + "\n\n")
-
-	keyW, valW := 3, 7
-	vals := make([]string, len(config.Settings))
-	for i, s := range config.Settings {
-		vals[i] = config.Get(*m.cfg, s.Key)
-		keyW = max(keyW, len(s.Key))
-		valW = max(valW, len(vals[i]))
+	if m.picking {
+		return m.pickerView()
 	}
-	for i, s := range config.Settings {
-		marker := "   "
-		key := fmt.Sprintf("%-*s", keyW, s.Key)
+	fields := config.Settings
+
+	labelW, valW := 0, len("(default VPC)")
+	disp := make([]string, len(fields))
+	for i, f := range fields {
+		disp[i] = f.Display(config.Get(*m.cfg, f.Key))
+		labelW = max(labelW, len(f.Label))
+		valW = max(valW, len(disp[i]))
+	}
+
+	header := []string{
+		"",
+		" " + ui.Title.Render("⚓ pier settings") +
+			ui.Dim.Render("  "+ui.Tilde(config.Path())+" · changes apply to new sessions"),
+		"",
+	}
+
+	var body []string
+	cursorLine, lastGroup := 0, ""
+	for i, f := range fields {
+		if f.Group != lastGroup {
+			if lastGroup != "" {
+				body = append(body, "")
+			}
+			body = append(body, m.groupHeader(f.Group))
+			lastGroup = f.Group
+		}
 		if i == m.setIdx {
-			marker = " " + ui.Accent.Render("▸") + " "
-			key = ui.Bold.Render(key)
+			cursorLine = len(body)
 		}
-		var val string
-		switch {
-		case i == m.setIdx && m.editing:
-			val = m.setInput + ui.Accent.Render("▌")
-		case vals[i] == "":
-			val = ui.Dim.Render(fmt.Sprintf("%-*s", valW, "(unset)"))
-		default:
-			val = fmt.Sprintf("%-*s", valW, vals[i])
-		}
-		fmt.Fprintf(&b, "%s%s  %s  %s\n", marker, key, val, ui.Dim.Render(s.Hint))
+		body = append(body, m.settingRow(i, f, disp[i], labelW, valW))
 	}
-	b.WriteString("\n " + ui.Dim.Render("secrets and baked images are managed by pier setup and pier bake") + "\n\n")
+	body = append(body, "")
+	body = append(body, m.readonlyLines()...)
 
+	var footer []string
+	footer = append(footer, m.detailFooter(fields[m.setIdx])...)
 	if m.status != "" {
 		if m.statusBad {
-			b.WriteString(" " + ui.Bad.Render("! "+m.status) + "\n")
+			footer = append(footer, " "+ui.Bad.Render("! "+m.status))
 		} else {
-			b.WriteString(" " + ui.Accent.Render("▸ "+m.status) + "\n")
+			footer = append(footer, " "+ui.Accent.Render("▸ "+m.status))
 		}
 	}
 	if m.editing {
-		b.WriteString(" " + ui.Keys("enter", "save", "esc", "cancel") + "\n")
+		footer = append(footer, " "+ui.Keys("enter", "save", "esc", "cancel"))
 	} else {
-		b.WriteString(" " + ui.Keys("enter", "edit", "esc", "back") + "\n")
+		verb := "edit"
+		if k := fields[m.setIdx].Kind; k == config.KindChoice || k == config.KindMachine {
+			verb = "choose"
+		}
+		footer = append(footer, " "+ui.Keys("↑↓", "move", "enter", verb, "esc", "back"))
 	}
+
+	body = m.windowBody(body, cursorLine, len(header)+len(footer))
+	return strings.Join(header, "\n") + "\n" +
+		strings.Join(body, "\n") + "\n" +
+		strings.Join(footer, "\n") + "\n"
+}
+
+// groupHeader labels a group; a cloud group that isn't the active driver reads
+// dim with a "used when…" note, matching its dimmed rows.
+func (m model) groupHeader(group string) string {
+	if group == "session" {
+		return " " + ui.Bold.Render("session")
+	}
+	if m.inactiveGroup(group) {
+		return " " + ui.Dim.Render(group+" — used when cloud is "+cloudName(group))
+	}
+	return " " + ui.Bold.Render(group)
+}
+
+// settingRow renders one field: accent cursor + bold when selected, the whole
+// line dimmed for the inactive cloud, the machine fields annotated with the
+// current type's specs. Padded as plain text before styling so the %-*s width
+// math survives (ANSI escapes would blow the column alignment).
+func (m model) settingRow(i int, f config.Field, disp string, labelW, valW int) string {
+	label := fmt.Sprintf("%-*s", labelW, f.Label)
+	hint := f.Hint
+	if f.Kind == config.KindMachine {
+		if h := m.machineHint(f); h != "" {
+			hint = h
+		}
+	}
+	if i == m.setIdx {
+		val := fmt.Sprintf("%-*s", valW, disp)
+		if m.editing {
+			val = m.setInput + ui.Accent.Render("▌")
+		}
+		return " " + ui.Accent.Render("▸") + " " + ui.Bold.Render(label) + "  " + val + "  " + ui.Dim.Render(hint)
+	}
+	val := fmt.Sprintf("%-*s", valW, disp)
+	if m.inactiveGroup(f.Group) {
+		return "   " + ui.Dim.Render(label+"  "+val+"  "+hint)
+	}
+	return "   " + label + "  " + val + "  " + ui.Dim.Render(hint)
+}
+
+// readonlyLines is the "managed elsewhere" section: what travels into sessions
+// and what's baked, shown so the answer to "what's carried?" doesn't require
+// opening config.toml. Strictly read-only — the write paths stay pier setup
+// and pier bake. The cursor never enters it.
+func (m model) readonlyLines() []string {
+	c := m.cfg
+
+	secrets := ui.Dim.Render("(none)")
+	if n := len(c.Secrets.Manifest); n > 0 {
+		show, more := c.Secrets.Manifest, ""
+		if n > 3 {
+			show, more = show[:3], fmt.Sprintf(" +%d more", n-3)
+		}
+		secrets = strings.Join(show, " · ") + more
+	}
+	token := "not set"
+	if c.Secrets.ClaudeOAuthToken != "" {
+		token = "set"
+	}
+	imgs := c.AWS.BakedAMIs
+	if c.Driver == "gcp-gce" {
+		imgs = c.GCP.BakedImages
+	}
+	baked := ui.Dim.Render("(none)")
+	if len(imgs) > 0 {
+		pairs := make([]string, 0, len(imgs))
+		for repo, img := range imgs {
+			pairs = append(pairs, repo+" → "+shorten(img, 22))
+		}
+		sort.Strings(pairs)
+		more := ""
+		if len(pairs) > 2 {
+			pairs, more = pairs[:2], fmt.Sprintf(" +%d more", len(pairs)-2)
+		}
+		baked = strings.Join(pairs, " · ") + more
+	}
+
+	// Pad by rune count, not bytes: "secrets → sessions" carries a multi-byte
+	// arrow, and %-*s would misalign the value column against the ASCII rows.
+	labelW := len([]rune("secrets → sessions"))
+	row := func(label, val, mgr string) string {
+		if pad := labelW - len([]rune(label)); pad > 0 {
+			label += strings.Repeat(" ", pad)
+		}
+		return "   " + ui.Dim.Render(label+"  ") + val + ui.Dim.Render("  ("+mgr+")")
+	}
+	return []string{
+		" " + ui.Dim.Render("managed elsewhere"),
+		row("secrets → sessions", secrets, "pier setup"),
+		row("claude token", token, "claude setup-token"),
+		row("baked images", baked, "pier bake"),
+	}
+}
+
+// detailFooter is the explanation panel for the selected field: a rule, the
+// label + prose, the underlying config key and default, another rule.
+func (m model) detailFooter(f config.Field) []string {
+	rule := ui.Dim.Render(strings.Repeat("─", m.ruleWidth()))
+	out := []string{rule}
+	lines := strings.Split(f.Detail, "\n")
+	out = append(out, " "+ui.Bold.Render(f.Label)+ui.Dim.Render(" — "+lines[0]))
+	for _, l := range lines[1:] {
+		out = append(out, " "+ui.Dim.Render(l))
+	}
+	meta := "config: " + f.Key
+	if f.Default != "" {
+		meta += " · default: " + f.Default
+	}
+	return append(out, " "+ui.Dim.Render(meta), rule)
+}
+
+// pickerView is the dropdown for a choice or machine field: the options with
+// their annotations, the current value marked, and (unless the field is a
+// closed enum) a custom… row that drops into the free-text editor.
+func (m model) pickerView() string {
+	f := config.Settings[m.setIdx]
+	var b strings.Builder
+	b.WriteString("\n " + ui.Title.Render("⚓ pier settings") + ui.Dim.Render("  "+f.Label) + "\n\n")
+	b.WriteString(" " + ui.Dim.Render(f.Label+" — "+strings.SplitN(f.Detail, "\n", 2)[0]) + "\n\n")
+
+	cur := config.Get(*m.cfg, f.Key)
+	leftW := 6
+	labels := make([]string, len(m.pickOpts))
+	for i, o := range m.pickOpts {
+		labels[i] = o.Label
+		if labels[i] == "" {
+			labels[i] = o.Value
+		}
+		leftW = max(leftW, len(labels[i]))
+	}
+	for i, o := range m.pickOpts {
+		row := fmt.Sprintf("%-*s", leftW, labels[i])
+		if o.Desc != "" {
+			row += "  " + o.Desc
+		}
+		if o.Value == cur {
+			row += "  (current)"
+		}
+		b.WriteString(m.pickRow(i, row))
+	}
+	if !f.NoCustom {
+		b.WriteString(m.pickRow(len(m.pickOpts), fmt.Sprintf("%-*s  ", leftW, "custom…")+"type your own"))
+	}
+	b.WriteString("\n " + ui.Keys("↑↓", "move", "enter", "select", "esc", "cancel") + "\n")
 	return b.String()
+}
+
+func (m model) pickRow(i int, row string) string {
+	if i == m.pickIdx {
+		return " " + ui.Accent.Render("▸") + " " + ui.Bold.Render(row) + "\n"
+	}
+	return "   " + row + "\n"
+}
+
+// windowBody trims the settings body to what the terminal can hold, centered
+// on the selected row — same idea as the session table, so the header and
+// footer never scroll off the alternate screen. height 0 (tests) renders all.
+func (m model) windowBody(body []string, cursorLine, chrome int) []string {
+	if m.height == 0 {
+		return body
+	}
+	budget := max(3, m.height-chrome-1)
+	if len(body) <= budget {
+		return body
+	}
+	lo := min(max(0, cursorLine-budget/2), len(body)-budget)
+	return body[lo : lo+budget]
+}
+
+func (m model) inactiveGroup(group string) bool {
+	if group != "aws" && group != "gcp" {
+		return false
+	}
+	active := m.cfg.Driver
+	if active == "" {
+		active = "aws-ec2"
+	}
+	return driverID(group) != active
+}
+
+func (m model) machineHint(f config.Field) string {
+	if m.opts.SettingsMachines == nil {
+		return ""
+	}
+	cur := config.Get(*m.cfg, f.Key)
+	for _, mc := range m.opts.SettingsMachines(driverID(f.Group), cur) {
+		if mc.Type == cur {
+			return fmt.Sprintf("%s vCPU · %s GiB · %s", mc.CPU, mc.Mem, mc.Cost)
+		}
+	}
+	return ""
+}
+
+func (m model) ruleWidth() int {
+	if m.width <= 0 {
+		return 58
+	}
+	return min(58, max(20, m.width-2))
+}
+
+func cloudName(group string) string {
+	if group == "gcp" {
+		return "GCP"
+	}
+	return "AWS"
+}
+
+func shorten(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
 }
 
 // listRows is the table's row budget: terminal height minus every non-row

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -43,35 +43,115 @@ func TestViewStates(t *testing.T) {
 	}
 }
 
-// The settings page renders every settable key and rejects bad values while
-// editing (staying in edit so the value can be fixed) without touching disk.
+// The settings page groups fields under human labels, shows the current
+// values, surfaces the read-only "managed elsewhere" section, and explains
+// the selected field in the detail footer.
 func TestSettingsPage(t *testing.T) {
 	cfg := config.Default()
 	m := model{mode: modeSettings, cfg: &cfg}
 
 	v := m.View()
-	for _, want := range []string{"pier settings", "idle_timeout", "aws.instance_type", "t4g.medium"} {
+	for _, want := range []string{
+		"pier settings",         // title
+		"session", "aws", "gcp", // group headers
+		"auto-park", "machine", "connection", // human labels
+		"t4g.medium",        // a current value
+		"managed elsewhere", // read-only section
+		"claude token",      // a read-only row
+		"config: driver",    // detail footer for the selected (first) field
+	} {
 		if !strings.Contains(v, want) {
 			t.Errorf("settings view missing %q:\n%s", want, v)
 		}
 	}
+	// The raw TOML keys are gone from the rows — only the footer names them.
+	if strings.Contains(v, "idle_timeout ") {
+		t.Errorf("row still shows a raw config key instead of a label:\n%s", v)
+	}
+}
 
-	// Move to idle_timeout, edit, type a bad duration, try to save.
-	m.setIdx = 1 // idle_timeout
+// A free-text field (gcp.project) opens the editor on enter and, on a bad
+// value, stays in edit with an error without touching disk.
+func TestSettingsTextValidation(t *testing.T) {
+	cfg := config.Default()
+	m := model{mode: modeSettings, cfg: &cfg, setIdx: fieldIndex(t, "gcp.project")}
+
 	got, _ := m.updateSettings(tea.KeyMsg{Type: tea.KeyEnter})
 	m = got.(model)
-	if !m.editing || m.setInput != "30m" {
-		t.Fatalf("enter must start editing with the current value, got editing=%v input=%q", m.editing, m.setInput)
+	if !m.editing {
+		t.Fatalf("enter on a text field must open the editor, got editing=%v picking=%v", m.editing, m.picking)
 	}
-	m.setInput = "not-a-duration"
+	m.setInput = "Bad_Project"
 	got, _ = m.updateSettings(tea.KeyMsg{Type: tea.KeyEnter})
 	m = got.(model)
 	if !m.editing || !m.statusBad {
-		t.Errorf("bad duration must stay in edit with an error, got editing=%v status=%q", m.editing, m.status)
+		t.Errorf("a bad project id must stay in edit with an error, got editing=%v status=%q", m.editing, m.status)
 	}
-	if cfg.IdleTimeout != "30m" {
-		t.Errorf("bad value leaked into config: %q", cfg.IdleTimeout)
+	if cfg.GCP.Project != "" {
+		t.Errorf("a rejected value leaked into config: %q", cfg.GCP.Project)
 	}
+}
+
+// A choice field (auto-park / idle_timeout) opens a picker preselected on the
+// current value; selecting a different option saves it.
+func TestSettingsChoicePicker(t *testing.T) {
+	cfg := config.Default() // idle_timeout defaults to 30m
+	m := model{mode: modeSettings, cfg: &cfg, setIdx: fieldIndex(t, "idle_timeout")}
+
+	got, _ := m.updateSettings(tea.KeyMsg{Type: tea.KeyEnter})
+	m = got.(model)
+	if !m.picking {
+		t.Fatalf("enter on a choice field must open the picker, got picking=%v editing=%v", m.picking, m.editing)
+	}
+	if m.pickOpts[m.pickIdx].Value != "30m" {
+		t.Errorf("picker must preselect the current value, got %q", m.pickOpts[m.pickIdx].Value)
+	}
+	if v := m.View(); !strings.Contains(v, "(current)") || !strings.Contains(v, "custom…") {
+		t.Errorf("picker must mark the current option and offer custom…:\n%s", v)
+	}
+	// Move to a different option and select it.
+	got, _ = m.updateSettings(tea.KeyMsg{Type: tea.KeyDown})
+	m = got.(model)
+	want := m.pickOpts[m.pickIdx].Value
+	got, _ = m.updateSettings(tea.KeyMsg{Type: tea.KeyEnter})
+	m = got.(model)
+	if m.picking || cfg.IdleTimeout != want {
+		t.Errorf("selecting an option must save it and close the picker, got picking=%v idle=%q want=%q", m.picking, cfg.IdleTimeout, want)
+	}
+}
+
+// The machine field builds its picker from the injected catalog and converts
+// each machine into an annotated option.
+func TestSettingsMachinePicker(t *testing.T) {
+	cfg := config.Default()
+	m := model{mode: modeSettings, cfg: &cfg, setIdx: fieldIndex(t, "aws.instance_type"),
+		opts: Options{SettingsMachines: func(driverID, cur string) []driver.Machine {
+			return awsec2.Machines(cur)
+		}}}
+	got, _ := m.updateSettings(tea.KeyMsg{Type: tea.KeyEnter})
+	m = got.(model)
+	if !m.picking || len(m.pickOpts) == 0 {
+		t.Fatalf("enter on the machine field must open a populated picker, got picking=%v opts=%d", m.picking, len(m.pickOpts))
+	}
+	if m.pickOpts[m.pickIdx].Value != "t4g.medium" {
+		t.Errorf("picker must preselect the configured type, got %q", m.pickOpts[m.pickIdx].Value)
+	}
+	if v := m.View(); !strings.Contains(v, "vCPU") || !strings.Contains(v, "GiB") {
+		t.Errorf("machine picker must show specs:\n%s", v)
+	}
+}
+
+// fieldIndex is the position of key in config.Settings, failing the test if
+// the key was renamed out from under it.
+func fieldIndex(t *testing.T, key string) int {
+	t.Helper()
+	for i, f := range config.Settings {
+		if f.Key == key {
+			return i
+		}
+	}
+	t.Fatalf("no settable field %q", key)
+	return 0
 }
 
 // The m key opens the resize picker preselected on the session's current


### PR DESCRIPTION
Cleans up the `s` settings page in the TUI: it was a flat list of raw TOML keys, mostly free-text with unclear validation. Now it's grouped, labeled, explained, and uses dropdowns wherever a field is really an enum.

## The bug this also fixes
`config.Set("driver", …)` accepted *any* string and `newDriver` then silently fell back to the AWS driver — so a typo like `gcp` (instead of `gcp-gce`) quietly ran your GCP intentions on EC2. It's now a strict enum (with `aws`/`gcp` aliases), rejected at entry. Region, zone, subnet, project, and instance/machine types get format validation too, and negative durations are rejected — bad input fails in the settings page instead of minutes later at create time.

## What changed
- **Grouped** into `session` / `aws` / `gcp`; the inactive cloud's group is dimmed but still editable (pre-fill GCP before switching).
- **Human labels** (`cloud`, `auto-park`, `connection`, `machine`) on the rows; the raw config key still shows in the detail footer so it maps back to `config.toml`.
- **Dropdowns** for enum-ish fields: cloud and connection are closed 2-option pickers; durations, regions/zones, disk sizes, and machine types are curated lists with a `custom…` row that drops to validated free text. The machine picker reuses the resize catalog (vCPU · GiB · cost).
- **Detail footer** per selected field — prose, format, config key, default.
- **A read-only "managed elsewhere" section** finally showing what travels into sessions: the secrets manifest, whether the Claude token is set (never the value), and baked images per repo — each tagged with the command that owns it (`pier setup` / `pier bake`).
- Body **windows to terminal height** like the session table, so the title and footer never scroll off the alt screen.

`config` stays pure data + validation (the single write path); the TUI renders it. The machine catalog is injected via a new `SettingsMachines` callback so the TUI still doesn't import the concrete drivers.

## Commits
1. `config:` schema + hardened validation (self-contained; builds and tests green on its own).
2. `tui:` the page redesign + `SettingsMachines` wiring.

## Tests
Added hardened-validator coverage in `set_test.go`, and TUI tests for grouped rendering, the text-edit reject-and-stay path, the choice picker, and the machine picker. `go vet` + full `go test` green.