### PR TITLE
pool: repo-scoped warm session pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ intact. And to see what the agent built,
 |---|---|
 | running | `~$0.04/h` |
 | parked | `~$3-4/mo` (disk only) |
+| warm pool member (parked) | `~$3-4/mo` (disk only) |
 
 There is no control plane. No server, no database, no daemon on your laptop.
 Session state lives in instance tags. Every byte between you and the VM is
@@ -191,12 +192,13 @@ for pier VMs and one allow rule above it for exactly Google's IAP range
 
 ```
 pier                      the TUI: sessions live-updating
-                          enter attach · n new · d delete · p pin · m resize · s settings · r refresh · q quit
+                          enter attach · n new · d delete · p pin · m resize · w pools · s settings · r refresh · q quit
 pier <branch> [base]      new session off base (default HEAD), then attach
     -d, --detach          create without attaching
     --idle <dur|never>    idle self-park timeout (default 30m)
     --cap <dur|never>     unattended runaway cap (default 8h)
     --no-park             shorthand for --idle never
+    --no-pool             skip this repo's warm pool for this create
 pier ls                   plain list (pipeable)
 pier attach <session>     attach (parked sessions auto-resume, ~20-60s)
 pier logs <session>       show the setup script log (-f follows)
@@ -204,6 +206,10 @@ pier rm <session> [-f]    destroy the session and its disk
 pier keep <session>       pin: disable idle self-park
 pier resize <session> <type>   grow/shrink the VM (~1-2 min, same CPU arch)
 pier bake                 prebake this repo's session image (~1-2 min creates)
+pier pool                 warm pool status + cost (the TUI's w page, scriptable)
+pier pool set <size>      keep <size> warm sessions ready for this repo (0 = off)
+pier pool fill [--detach] top this repo's pool up to size now
+pier pool drain [repo]    destroy a repo's warm members
 pier mcp login <session>  one-time browser approvals for OAuth MCP servers
 pier proxy                every running session as <session>.pier (macOS)
 pier port <session> <p>   manual port forward (8080:3000 = local:session)
@@ -367,6 +373,29 @@ pier bake    # one throwaway instance + your .pier-bake.sh, snapshotted as an im
 Creates from a baked image drop to a minute or two. Images are keyed to
 the repo, so one project's toolchain never bleeds into another's. Re-baking
 supersedes the old image, and `pier teardown` sweeps them all by tag.
+
+### Warm pools: the create is already done
+
+Even a baked create spends a minute booting and then runs your setup script.
+A warm pool does that work ahead of time:
+
+```
+cd ~/code/shop && pier pool set 2
+```
+
+pier now keeps two parked, **setup-complete** sessions ready for `shop`. The
+next `pier <branch>` claims one instead of creating — resume, check out your
+branch, re-push secrets, apply your dirty edits — and refills the pool in
+the background. An empty pool just means a normal create; the pool
+accelerates, never gates, and `--no-pool` skips it for one create.
+
+Warm members are parked instances, so each costs disk only (~$3-4/mo).
+They recycle themselves when they go stale — after a re-bake, a
+setup-script change, or 14 days (`pool.max_age`) — and `pier pool` shows
+every pool you're holding with what it costs. In the TUI, `w` opens the
+pool page: `+`/`-` and enter size the current repo's pool, `d` drains any
+repo's members, and the header counts what's warm. Strictly opt-in;
+`pier pool set 0` turns it off and drains.
 
 ### Setup that can't fail silently
 

--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ import (
 	"github.com/kerem-kaynak/pier/internal/driver/awsec2"
 	"github.com/kerem-kaynak/pier/internal/driver/gcpgce"
 	"github.com/kerem-kaynak/pier/internal/driver/payload"
+	"github.com/kerem-kaynak/pier/internal/pool"
 	"github.com/kerem-kaynak/pier/internal/proxy"
 	"github.com/kerem-kaynak/pier/internal/tui"
 	"github.com/kerem-kaynak/pier/internal/ui"
@@ -56,6 +58,7 @@ const usage = `usage:
       --idle <dur|never>      idle self-park timeout (default from config)
       --cap <dur|never>       unattended runaway cap
       --no-park               shorthand for --idle never
+      --no-pool               skip this repo's warm pool for this create
   pier ls                   list sessions
   pier attach <session>     attach (auto-resumes if parked)
   pier logs <session>       show the setup script log (-f follows)
@@ -69,6 +72,10 @@ const usage = `usage:
   pier rm <session> [-f]    destroy session and its disk
   pier keep <session>       pin: disable idle self-park
   pier resize <session> <type>  grow/shrink the VM (running: ~1-2 min park+resume; same arch only)
+  pier pool                 warm pool status + cost
+  pier pool set <size>      keep <size> warm sessions ready for this repo (0 = off)
+  pier pool fill [--detach] top this repo's pool up to size now
+  pier pool drain [repo]    destroy a repo's warm members
   pier setup                first-run wizard (creates cloud groundwork)
       --print-admin           print the admin-runnable setup commands instead
   pier doctor               environment + account checks
@@ -102,6 +109,8 @@ func main() {
 		cmdKeep(args[1:])
 	case "resize":
 		cmdResize(args[1:])
+	case "pool":
+		cmdPool(args[1:])
 	case "setup":
 		cmdSetup(args[1:])
 	case "doctor":
@@ -213,10 +222,11 @@ func cmdNew(args []string) {
 		}
 	}
 	fs := flag.NewFlagSet("new", flag.ExitOnError)
-	var detach, noPark bool
+	var detach, noPark, noPool bool
 	fs.BoolVar(&detach, "d", false, "")
 	fs.BoolVar(&detach, "detach", false, "")
 	fs.BoolVar(&noPark, "no-park", false, "")
+	fs.BoolVar(&noPool, "no-pool", false, "")
 	idleS := fs.String("idle", "", "")
 	capS := fs.String("cap", "", "")
 	fs.Parse(flagArgs)
@@ -242,6 +252,9 @@ func cmdNew(args []string) {
 		fatal(err)
 	}
 	for _, s := range sessions {
+		if s.PoolGen != "" {
+			continue // unclaimed pool members hold placeholder names, not sessions'
+		}
 		if s.Name == branch {
 			fatal(fmt.Errorf("session %q already exists — `pier attach %s`", branch, branch))
 		}
@@ -264,13 +277,48 @@ func cmdNew(args []string) {
 	image := cfg.BakedImage(filepath.Base(repo))
 	fmt.Printf("%s %s\n", ui.Bold.Render("creating "+branch),
 		ui.Dim.Render(fmt.Sprintf("(%s @ %s)", filepath.Base(repo), base)))
-	sess, err := drv.Create(ctx, driver.CreateSpec{
-		Name: branch, Repo: repo, Branch: branch, BaseRef: base, Image: image,
-		IdleTimeout: idle, UnattendedCap: cap_,
-		Progress: func(step string) { fmt.Println(ui.Step(step)) },
-	})
-	if err != nil {
-		fatal(err)
+
+	// A configured pool turns the create into claim-a-warm-member (resume +
+	// freshen, setup already done); an empty or lost pool falls through to the
+	// full create below.
+	poolable := cfg.PoolSize(filepath.Base(repo)) > 0 && !noPool
+	var sess *driver.Session
+	if poolable {
+		pp, err := poolParams(cfg, drv, repo)
+		if err != nil {
+			fatal(err)
+		}
+		// This create's --idle/--cap land on the claimed member's supervisor.
+		pp.IdleTimeout, pp.UnattendedCap = idle, cap_
+		if sess, err = pool.Claim(ctx, pp, sessions, branch, branch, base); err != nil {
+			// The pool accelerates, never gates: whatever broke the claim
+			// (bad name, throttled API), the create below gives the same
+			// answer or a session.
+			fmt.Println(ui.Warn.Render("!") + " claim failed: " + err.Error())
+			sess = nil
+		}
+		if sess == nil {
+			fmt.Println(ui.Step("no warm member to claim — creating fresh"))
+		}
+	}
+	if sess == nil {
+		sess, err = drv.Create(ctx, driver.CreateSpec{
+			Name: branch, Repo: repo, Branch: branch, BaseRef: base, Image: image,
+			IdleTimeout: idle, UnattendedCap: cap_,
+			Progress: func(step string) { fmt.Println(ui.Step(step)) },
+		})
+		if err != nil {
+			fatal(err)
+		}
+	}
+	if poolable {
+		// Top the pool back up in the background — after a claim (a member was
+		// consumed) and after a fallback create (the pool was short) alike.
+		if logPath, err := spawnPoolFill(repo); err != nil {
+			fmt.Println(ui.Warn.Render("!") + ui.Dim.Render(" pool refill didn't start: "+err.Error()))
+		} else {
+			fmt.Println(ui.Dim.Render("pool refilling in the background — log: " + ui.Tilde(logPath)))
+		}
 	}
 	stop() // create done — ctrl-c back to its default for the prompt + attach
 	fmt.Println(ui.OK.Render("session " + sess.Name + " ready"))
@@ -370,13 +418,31 @@ func waitReachable(drv driver.Driver, id string, timeout time.Duration) error {
 
 func cmdLS() {
 	_, drv := loadDriver()
-	sessions, err := drv.List(context.Background())
+	all, err := drv.List(context.Background())
 	if err != nil {
 		fatal(err)
 	}
+	// Warm pool members are inventory, not sessions: one dim summary line
+	// below the table instead of rows.
+	var sessions []driver.Session
+	members := 0
+	for _, s := range all {
+		if s.PoolGen != "" {
+			members++
+			continue
+		}
+		sessions = append(sessions, s)
+	}
 	enrich(drv, sessions)
+	poolLine := ""
+	if members > 0 {
+		poolLine = ui.Dim.Render(fmt.Sprintf("+ %d warm pool member(s) — `pier pool`", members))
+	}
 	if len(sessions) == 0 {
 		fmt.Println(ui.Dim.Render("no sessions — start one with `pier <branch>`"))
+		if poolLine != "" {
+			fmt.Println(poolLine)
+		}
 		return
 	}
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
@@ -388,6 +454,9 @@ func cmdLS() {
 		anySetupFailed = anySetupFailed || s.Setup == "failed"
 	}
 	w.Flush()
+	if poolLine != "" {
+		fmt.Println(poolLine)
+	}
 	if anyStrained {
 		fmt.Println("\n" + ui.Warn.Render("!") + ui.Dim.Render(" strained = sustained cpu/mem pressure — grow with `pier resize <session> <type>`"))
 	}
@@ -416,7 +485,9 @@ func stateLabel(s driver.Session) string {
 func enrich(drv driver.Driver, sessions []driver.Session) {
 	var wg sync.WaitGroup
 	for i := range sessions {
-		if sessions[i].State != driver.StateRunning {
+		// Pool members run headless between create and park; their beacon
+		// detail is nobody's business until they're claimed.
+		if sessions[i].State != driver.StateRunning || sessions[i].PoolGen != "" {
 			continue
 		}
 		wg.Add(1)
@@ -487,6 +558,9 @@ func match(drv driver.Driver, query string) driver.Session {
 	}
 	var hits []driver.Session
 	for _, s := range sessions {
+		if s.PoolGen != "" {
+			continue // unclaimed pool members are managed via `pier pool`, not by name
+		}
 		if s.Name == query {
 			return s
 		}
@@ -822,6 +896,254 @@ func cmdResize(args []string) {
 	fmt.Println(ui.OK.Render(s.Name + " is now a " + itype))
 }
 
+// --- warm pools --------------------------------------------------------------------
+
+// poolParams assembles everything internal/pool needs from config + driver,
+// including the generation fingerprint — which is why it must run from inside
+// the repo (the local setup script feeds the hash).
+func poolParams(cfg config.Config, drv driver.Driver, repoRoot string) (pool.Params, error) {
+	maxAge, err := cfg.PoolMaxAge()
+	if err != nil {
+		return pool.Params{}, err
+	}
+	idle, err := config.ParkDuration(cfg.IdleTimeout)
+	if err != nil {
+		return pool.Params{}, err
+	}
+	cap_, err := config.ParkDuration(cfg.UnattendedCap)
+	if err != nil {
+		return pool.Params{}, err
+	}
+	itype, disk := cfg.AWS.InstanceType, cfg.AWS.DiskGiB
+	if cfg.Driver == "gcp-gce" {
+		itype, disk = cfg.GCP.MachineType, cfg.GCP.DiskGiB
+	}
+	repo := filepath.Base(repoRoot)
+	image := cfg.BakedImage(repo)
+	return pool.Params{
+		Driver:      drv,
+		RepoRoot:    repoRoot,
+		Gen:         pool.Generation(drv.Name(), image, itype, disk, pool.SetupScript(repoRoot)),
+		Size:        cfg.PoolSize(repo),
+		MaxAge:      maxAge,
+		Image:       image,
+		IdleTimeout: idle, UnattendedCap: cap_,
+		Manifest: cfg.Secrets.Manifest, SessionEnv: sessionEnv(cfg),
+		Progress: func(step string) { fmt.Println(ui.Step(step)) },
+	}, nil
+}
+
+// cmdPool: repo-scoped warm session pools — parked, setup-complete members
+// that `pier <branch>` claims instead of creating. The TUI's w page is the
+// primary surface; these commands are its scriptable equivalents.
+func cmdPool(args []string) {
+	if len(args) == 0 {
+		poolStatus()
+		return
+	}
+	switch args[0] {
+	case "set":
+		poolSet(args[1:])
+	case "fill":
+		poolFill(args[1:])
+	case "drain":
+		poolDrain(args[1:])
+	default:
+		fatal(fmt.Errorf("usage: pier pool [set <size> | fill [--detach] | drain [repo]]"))
+	}
+}
+
+// poolStatus lists every pool the account holds — configured ones and
+// leftovers alike — with what the parked members actually cost.
+func poolStatus() {
+	cfg, drv := loadDriver()
+	sessions, err := drv.List(context.Background())
+	if err != nil {
+		fatal(err)
+	}
+	repos := map[string]bool{}
+	for r := range cfg.Pool.Sizes {
+		repos[r] = true
+	}
+	for _, s := range sessions {
+		if s.PoolGen != "" {
+			repos[s.Repo] = true
+		}
+	}
+	if len(repos) == 0 {
+		fmt.Println(ui.Dim.Render("no warm pools — `pier pool set <size>` from a repo keeps sessions ready to claim"))
+		return
+	}
+	// Staleness is only computable for the repo we're standing in: the
+	// generation hashes its local setup script.
+	curRepo, curGen := "", ""
+	if out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output(); err == nil {
+		root := strings.TrimSpace(string(out))
+		if pp, err := poolParams(cfg, drv, root); err == nil {
+			curRepo, curGen = filepath.Base(root), pp.Gen
+		}
+	}
+	maxAge, _ := cfg.PoolMaxAge() // unparsable → 0, which skips the age check
+	names := make([]string, 0, len(repos))
+	for r := range repos {
+		names = append(names, r)
+	}
+	sort.Strings(names)
+	now := time.Now()
+	for _, repo := range names {
+		st := tui.FoldPool(sessions, repo, curRepo, curGen, maxAge, now)
+		line := fmt.Sprintf("%s: %d/%d warm", repo, st.Ready, cfg.PoolSize(repo))
+		if len(st.Ages) > 0 {
+			line += ui.Dim.Render(" (ages " + strings.Join(st.Ages, ", ") + ")")
+		}
+		if st.Filling > 0 {
+			line += fmt.Sprintf(", %d filling", st.Filling)
+		}
+		if st.Stale > 0 {
+			line += ui.Warn.Render(fmt.Sprintf(", %d stale", st.Stale)) + ui.Dim.Render(" (recycles on next claim/fill)")
+		}
+		if st.Ready > 0 {
+			line += ui.Dim.Render(fmt.Sprintf(" — %d × ~$3-4/mo disk", st.Ready))
+		}
+		if cfg.PoolSize(repo) == 0 {
+			line += ui.Warn.Render(" — no pool configured") + ui.Dim.Render(" — `pier pool drain "+repo+"` removes them")
+		}
+		fmt.Println(line)
+	}
+}
+
+func poolSet(args []string) {
+	if len(args) != 1 {
+		fatal(fmt.Errorf("usage: pier pool set <size>   (0-8; 0 turns the pool off — run from inside the repo)"))
+	}
+	n, err := strconv.Atoi(args[0])
+	if err != nil || n < 0 || n > 8 {
+		fatal(fmt.Errorf("pool size: want a number 0-8 (got %q)", args[0]))
+	}
+	cfg, drv := loadDriver()
+	root := repoRoot()
+	if err := applyPoolSize(cfg, drv, root, n, func(s string) { fmt.Println(ui.Step(s)) }); err != nil {
+		fatal(err)
+	}
+	repo := filepath.Base(root)
+	if n == 0 {
+		fmt.Println(ui.OK.Render("pool off for " + repo))
+		return
+	}
+	fmt.Println(ui.OK.Render(fmt.Sprintf("pool size %d for %s", n, repo)) +
+		ui.Dim.Render(" — each warm member costs ~$3-4/mo parked (disk only)"))
+	fmt.Println(ui.Dim.Render("filling in the background — log: " + ui.Tilde(poolLogPath(repo))))
+}
+
+// applyPoolSize is the one write path for a pool size, shared by the CLI and
+// the TUI: saves the config, then drains (0) or starts a detached fill (>0).
+func applyPoolSize(cfg config.Config, drv driver.Driver, repoRoot string, n int, progress func(string)) error {
+	repo := filepath.Base(repoRoot)
+	cfg.SetPoolSize(repo, n)
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	if n == 0 {
+		sessions, err := drv.List(context.Background())
+		if err != nil {
+			return err
+		}
+		_, err = pool.Drain(context.Background(), drv, sessions, repo, progress)
+		return err
+	}
+	_, err := spawnPoolFill(repoRoot)
+	return err
+}
+
+func poolFill(args []string) {
+	detach := len(args) > 0 && (args[0] == "--detach" || args[0] == "-d")
+	cfg, drv := loadDriver()
+	root := repoRoot()
+	repo := filepath.Base(root)
+	if cfg.PoolSize(repo) == 0 {
+		fatal(fmt.Errorf("no pool configured for %s — `pier pool set <size>` first", repo))
+	}
+	if detach {
+		if _, err := spawnPoolFill(root); err != nil {
+			fatal(err)
+		}
+		fmt.Println(ui.Dim.Render("filling in the background — log: " + ui.Tilde(poolLogPath(repo))))
+		return
+	}
+	pp, err := poolParams(cfg, drv, root)
+	if err != nil {
+		fatal(err)
+	}
+	// ctrl-c mid-fill must cancel the ctx (not just kill the process) so
+	// Create's deferred cleanup can terminate a half-made member.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := pool.Fill(ctx, pp); err != nil {
+		fatal(err)
+	}
+}
+
+func poolDrain(args []string) {
+	cfg, drv := loadDriver()
+	var repo string
+	if len(args) > 0 {
+		repo = args[0]
+	} else {
+		repo = filepath.Base(repoRoot())
+	}
+	sessions, err := drv.List(context.Background())
+	if err != nil {
+		fatal(err)
+	}
+	count, err := pool.Drain(context.Background(), drv, sessions, repo, func(s string) { fmt.Println(ui.Step(s)) })
+	if err != nil {
+		fatal(err)
+	}
+	if count == 0 {
+		fmt.Println(ui.Dim.Render("no warm members for " + repo))
+		return
+	}
+	fmt.Println(ui.OK.Render(fmt.Sprintf("drained %d member(s)", count)))
+	if n := cfg.PoolSize(repo); n > 0 {
+		fmt.Println(ui.Dim.Render(fmt.Sprintf("pool size for %s is still %d — the next claim or fill re-warms it; `pier pool set 0` turns it off", repo, n)))
+	}
+}
+
+func poolLogPath(repo string) string {
+	return filepath.Join(config.Dir(), "logs", "pool-"+repo+".log")
+}
+
+// spawnPoolFill re-execs `pier pool fill` as a detached child working in
+// repoRoot — the spawnCreate pattern — so a refill survives the invoking
+// command (or the TUI) exiting.
+func spawnPoolFill(repoRoot string) (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	logPath := poolLogPath(filepath.Base(repoRoot))
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		return "", err
+	}
+	// Append, never truncate: a claim can spawn a refill while the previous
+	// fill is still writing here, and clobbering a live writer's log turns
+	// both runs into confetti. Fills are rare enough that growth is noise.
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	cmd := exec.Command(exe, "pool", "fill")
+	cmd.Dir = repoRoot
+	cmd.Stdout, cmd.Stderr = f, f
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+	go cmd.Wait() // reap if this process outlives the fill
+	return logPath, nil
+}
+
 // --- setup / doctor / bake / teardown ---------------------------------------------
 
 func cmdSetup(args []string) {
@@ -832,8 +1154,8 @@ func cmdSetup(args []string) {
 }
 
 func cmdDoctor() {
-	cfg, err := config.Load()
-	if err != nil {
+	cfg, cfgErr := config.Load()
+	if cfgErr != nil {
 		fmt.Println(ui.Warn.Render("!") + ui.Dim.Render(" no config yet — checking with defaults (run `pier setup`)"))
 		cfg = config.Default()
 	}
@@ -841,7 +1163,41 @@ func cmdDoctor() {
 	if err != nil {
 		fatal(err)
 	}
-	if !printChecks(drv.Doctor(context.Background())) {
+	checks := drv.Doctor(context.Background())
+	// Orphaned pool members are parked money nothing will ever claim: they
+	// belong to repos whose pool was turned off (or another machine's config).
+	// Members unparked past the fill grace are worse — a fill died before its
+	// member parked, and the instance bills at full rate until something
+	// notices; the next fill reconciles it away, but only doctor and the pool
+	// pages will say so unprompted.
+	if cfgErr == nil {
+		if sessions, err := drv.List(context.Background()); err == nil {
+			orphans, stuck := map[string]int{}, map[string]int{}
+			for _, s := range sessions {
+				switch {
+				case s.PoolGen == "" || s.State == driver.StateDeleting:
+				case s.State != driver.StateParked && s.State != driver.StateDead &&
+					time.Since(s.Created) >= pool.FillGrace:
+					stuck[s.Repo]++
+				case cfg.PoolSize(s.Repo) == 0:
+					orphans[s.Repo]++
+				}
+			}
+			for repo, n := range orphans {
+				checks = append(checks, driver.Check{
+					Name:   "pool " + repo,
+					Detail: fmt.Sprintf("%d warm member(s) but no pool configured — `pier pool drain %s`", n, repo),
+				})
+			}
+			for repo, n := range stuck {
+				checks = append(checks, driver.Check{
+					Name:   "pool " + repo,
+					Detail: fmt.Sprintf("%d member(s) stuck filling for 2h+ — running at full price; `pier pool fill` (from the repo) or `pier pool drain %s` recycles them", n, repo),
+				})
+			}
+		}
+	}
+	if !printChecks(checks) {
 		os.Exit(1)
 	}
 }
@@ -888,6 +1244,9 @@ func cmdBake() {
 		fatal(err)
 	}
 	fmt.Println(ui.OK.Render("baked "+img) + ui.Dim.Render(" — new "+name+" sessions now cold-start in ~1-2 min"))
+	if cfg.PoolSize(name) > 0 {
+		fmt.Println(ui.Dim.Render("the warm pool was built on the old image — members recycle on the next claim or `pier pool fill`"))
+	}
 }
 
 func cmdTeardown() {
@@ -895,10 +1254,28 @@ func cmdTeardown() {
 	if !confirm("remove all pier groundwork and baked images from the account?", false) {
 		return
 	}
+	// Pool members are invisible to `pier rm`, so teardown drains every pool
+	// itself — Teardown refuses while instances exist, and rightly so.
+	sessions, err := drv.List(context.Background())
+	if err != nil {
+		fatal(err)
+	}
+	repos := map[string]bool{}
+	for _, s := range sessions {
+		if s.PoolGen != "" {
+			repos[s.Repo] = true
+		}
+	}
+	for repo := range repos {
+		if _, err := pool.Drain(context.Background(), drv, sessions, repo, func(s string) { fmt.Println(ui.Step(s)) }); err != nil {
+			fatal(err)
+		}
+	}
 	if err := drv.Teardown(context.Background()); err != nil {
 		fatal(err)
 	}
 	cfg.ClearBakes()
+	cfg.Pool.Sizes = nil
 	cfg.Save()
 	fmt.Println(ui.OK.Render("groundwork removed — the account is clean"))
 }
@@ -920,7 +1297,22 @@ func confirm(prompt string, def bool) bool {
 // --- TUI --------------------------------------------------------------------------
 
 func cmdTUI() {
-	_, drv := loadDriver()
+	cfg, drv := loadDriver()
+	// Pool sizing edits the repo pier launched from; outside a repo the w page
+	// is read-only — a fill needs the local checkout and its setup script.
+	// Inside a repo whose pool params don't resolve (a broken [pool] value,
+	// say) the page is read-only too, but says why instead of pretending we
+	// are not in a repo.
+	curRoot, curRepo, curGen, poolNote := "", "", "", ""
+	if out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output(); err == nil {
+		curRoot = strings.TrimSpace(string(out))
+		if pp, err := poolParams(cfg, drv, curRoot); err == nil {
+			curRepo, curGen = filepath.Base(curRoot), pp.Gen
+		} else {
+			poolNote = "pool config unusable (" + err.Error() + ")"
+		}
+	}
+	poolMaxAge, _ := cfg.PoolMaxAge() // unparsable → 0, which skips the age check
 	err := tui.Run(tui.Options{
 		// Async: the TUI opens instantly and the quota fills in when it lands.
 		FetchQuota: func() string {
@@ -980,6 +1372,42 @@ func cmdTUI() {
 		RetryAttach: retryAttach,
 		WaitReachable: func(s driver.Session) error {
 			return waitReachable(drv, s.ID, 4*time.Minute)
+		},
+		CurrentRepo: curRepo,
+		CurrentGen:  curGen,
+		PoolMaxAge:  poolMaxAge,
+		PoolNote:    poolNote,
+		// Sizes reload from disk on each read so the w page sees a `pier pool
+		// set` from another terminal.
+		PoolSizes: func() map[string]int {
+			c, err := config.Load()
+			if err != nil {
+				return cfg.Pool.Sizes
+			}
+			return c.Pool.Sizes
+		},
+		PoolSet: func(size int) (string, error) {
+			c, err := config.Load()
+			if err != nil {
+				return "", err
+			}
+			if err := applyPoolSize(c, drv, curRoot, size, nil); err != nil {
+				return "", err
+			}
+			if size == 0 {
+				return "", nil
+			}
+			return poolLogPath(curRepo), nil
+		},
+		PoolFill: func() (string, error) {
+			return spawnPoolFill(curRoot)
+		},
+		PoolDrain: func(repo string) (int, error) {
+			sessions, err := drv.List(context.Background())
+			if err != nil {
+				return 0, err
+			}
+			return pool.Drain(context.Background(), drv, sessions, repo, nil)
 		},
 	})
 	if err != nil {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -310,8 +310,31 @@ and the IAP tunnel are simply slower).
    auto-transfer; the create prints which env files it is *not* carrying so
    a missing one fails loud at create, not deep in `make dev`.
 
-Cut for v1 (numbers didn't justify the moving parts): warm pools, mid-create
-quota polling.
+4. **Warm pools (opt-in, per repo)** — `pier pool set <size>` (or the TUI's
+   w page) keeps N parked, **setup-complete** members ready; `pier <branch>`
+   then claims one — resume + freshen (secrets re-push, branch at base,
+   dirty patch, supervisor conf reset, async setup re-run for drift) instead
+   of create + boot + full setup — and refills the pool detached in the
+   background. Members are normal per-user instances tagged
+   `pier:pool=<gen>`, where gen fingerprints
+   driver|image|type|disk|setup-script: a re-bake, config change, or setup
+   edit strands the old generation, which recycles at the next claim/fill;
+   members older than `pool.max_age` (default 14d) recycle too, bounding
+   repo drift. Concurrent claims race on a nonce written to the claim
+   tag/label and read back (providers have no tag CAS); the loser tries the
+   next member or falls through to a fresh create — the pool accelerates,
+   never gates. Parked members cost disk only (~$3–4/mo each, shown
+   wherever pools appear). No daemon holds any of this: a 2m idle leash at
+   fill self-parks a member even if the laptop dies mid-fill, and one that
+   dies before parking is torn down at the next mutating reconcile (2h
+   grace) and flagged by doctor and the pool pages meanwhile — nothing
+   burns money silently. Pools are keyed by repo basename, like baked
+   images: two checkouts sharing a directory name share a pool, and a
+   claim from the "wrong" one fails its freshen loudly and falls back to
+   a fresh create.
+
+Cut for v1 (numbers didn't justify the moving parts): mid-create quota
+polling.
 
 ## 8. Secrets
 
@@ -399,6 +422,10 @@ pier port <match> <p> [p...]  manual port forwards, zero-sudo any-OS fallback (3
 pier rm <match>         destroy (instance + disk)
 pier keep <match>       disable auto-park for a session
 pier resize <match> <type>  change VM size (running: park→modify→resume; same arch)
+pier pool               warm pool status + cost (TUI: the w page)
+pier pool set <size>    keep <size> warm sessions ready for the cwd repo (0 = off)
+pier pool fill [--detach]  top the cwd repo's pool up to size now
+pier pool drain [repo]  destroy a repo's warm members
 pier setup              wizard (--print-admin for the no-IAM-rights path)
 pier bake               build/refresh the prebaked image
 pier doctor             checks
@@ -430,15 +457,19 @@ disk_gib     = 40
 [secrets]
 manifest = [".codex/auth.json", ".codex/config.toml", ".claude/settings.json", ".claude/CLAUDE.md"]
 # claude_oauth_token = "..."  # from `claude setup-token` (macOS Keychain path)
+
+[pool]                         # warm pools (§7.4); strictly opt-in
+# max_age = "14d"              # member recycle age
+# [pool.sizes]                 # written by `pier pool set`, keyed by repo
+# shop = 2
 ```
 
 ## 13. v1 cut line
 
 In: AWS + GCP drivers, TUI, wizard (+print-admin, teardown), bake,
 overlapped create, supervisor parking (+keep/pin), one-way secrets copy,
-doctor, quota UX.
-Out (v1.1+): warm pools, hibernate/suspend park, k8s driver, `ls --all`,
-Windows.
+doctor, quota UX, warm pools (opt-in, added post-cut — §7.4).
+Out (v1.1+): hibernate/suspend park, k8s driver, `ls --all`, Windows.
 
 ## 14. Load-bearing bets → spikes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -501,3 +501,23 @@ create → attach-ready 1m44s**; resume → ready 56s; running resize 1m42s with
 creationTimestamp (AGE) preserved; the deny rule verified live — public :22
 probes fail while IAP attach works; rm and teardown swept the project back
 to pristine.
+
+Warm-pool E2E (2026-08-10/11, eu-central-1, t4g.medium, stock AMI — the test
+repo had no bake, so fills paid the cloud-init wait a baked image skips):
+`pool set 1` spawned the detached fill itself; fill → parked ready member
+2m49s (foreground run; the detached first run landed ~3m10s). **Claim →
+session ready 25.8s** (a second claim: 25s) — branch created, dirty patch
+carried, setup re-ran to status 0, and the supervisor conf flipped from the
+2m fill leash to the user's 1h idle (journal: `parking: idle for 1h0m0s`,
+exactly an hour after claim activity ceased). The detached refill built and
+parked a replacement unprompted. Two-terminal race against one member: the
+winner claimed in 25s, the loser printed `no warm member to claim — creating
+fresh` and fell back. The laptop-death backstop got an unplanned live trial:
+the laptop's network died mid-refill (even the cleanup terminate couldn't
+reach EC2) — the VM finished setup on its own, the fill leash parked it
+(`parking: idle for 2m0s`), and that member claimed cleanly the next morning.
+Editing `.pier-setup.sh` made the next fill print `recycling stale member …`
+and replace it. A repo whose setup script fails on stock (pnpm absent) had
+its member destroyed, never parked, and the claim fell back to a fresh
+create. Every failed create terminated its own instance; account swept back
+to baseline after — instances, volumes, keys, logs, config all gone.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	UnattendedCap string  `toml:"unattended_cap"` // duration or "never"
 	AWS           AWS     `toml:"aws"`
 	GCP           GCP     `toml:"gcp"`
+	Pool          Pool    `toml:"pool"`
 	Secrets       Secrets `toml:"secrets"`
 }
 
@@ -50,6 +51,18 @@ type GCP struct {
 	// the repo). Each repo bakes its own image so .pier-bake.sh toolchains
 	// don't bleed across projects.
 	BakedImages map[string]string `toml:"baked_images,omitempty"`
+}
+
+// Pool configures repo-scoped warm session pools. Strictly opt-in: a pool
+// exists only for repos with a size entry. Managed by `pier pool set`, not
+// the TUI settings — like baked images, a pool is a per-repo cost decision.
+type Pool struct {
+	// MaxAge recycles members older than this, bounding how far a warm
+	// checkout drifts from the default branch. Duration with a d unit
+	// allowed ("14d", "72h"); empty means 14d.
+	MaxAge string `toml:"max_age,omitempty"`
+	// Sizes: repo basename -> desired warm member count.
+	Sizes map[string]int `toml:"sizes,omitempty"`
 }
 
 type Secrets struct {
@@ -162,6 +175,42 @@ func (c *Config) ClearBakes() {
 	}
 	c.AWS.BakedAMI = ""
 	c.AWS.BakedAMIs = nil
+}
+
+// PoolSize is repo's configured warm-pool size (0 = no pool).
+func (c Config) PoolSize(repo string) int { return c.Pool.Sizes[repo] }
+
+// SetPoolSize records repo's desired pool size; 0 removes the entry so the
+// config doesn't accumulate dead rows for drained pools.
+func (c *Config) SetPoolSize(repo string, n int) {
+	if n <= 0 {
+		delete(c.Pool.Sizes, repo)
+		return
+	}
+	if c.Pool.Sizes == nil {
+		c.Pool.Sizes = map[string]int{}
+	}
+	c.Pool.Sizes[repo] = n
+}
+
+// PoolMaxAge parses pool.max_age, defaulting to 14 days. time.ParseDuration
+// has no days unit, so "14d" is handled here (whole days only).
+func (c Config) PoolMaxAge() (time.Duration, error) {
+	s := c.Pool.MaxAge
+	if s == "" {
+		return 14 * 24 * time.Hour, nil
+	}
+	if days, ok := strings.CutSuffix(s, "d"); ok {
+		if n, err := strconv.Atoi(days); err == nil && n > 0 {
+			return time.Duration(n) * 24 * time.Hour, nil
+		}
+		return 0, fmt.Errorf("pool.max_age: want a positive duration like 14d or 72h (got %q)", s)
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0, fmt.Errorf("pool.max_age: want a positive duration like 14d or 72h (got %q)", s)
+	}
+	return d, nil
 }
 
 // ParkDuration parses "30m" / "8h" / "never" (or "0") into a duration;

--- a/internal/config/pool_test.go
+++ b/internal/config/pool_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPoolSize(t *testing.T) {
+	cfg := Default()
+	if n := cfg.PoolSize("shop"); n != 0 {
+		t.Errorf("PoolSize on an empty config = %d, want 0 (pools are opt-in)", n)
+	}
+	cfg.SetPoolSize("shop", 2)
+	if n := cfg.PoolSize("shop"); n != 2 {
+		t.Errorf("PoolSize = %d, want 2", n)
+	}
+	cfg.SetPoolSize("shop", 0)
+	if _, ok := cfg.Pool.Sizes["shop"]; ok {
+		t.Error("SetPoolSize(0) must remove the entry, not store a dead row")
+	}
+}
+
+func TestPoolMaxAge(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want time.Duration
+		ok   bool
+	}{
+		{"", 14 * 24 * time.Hour, true}, // default
+		{"7d", 7 * 24 * time.Hour, true},
+		{"72h", 72 * time.Hour, true},
+		{"0d", 0, false},
+		{"-3d", 0, false},
+		{"soon", 0, false},
+		{"-72h", 0, false},
+	} {
+		cfg := Config{Pool: Pool{MaxAge: c.in}}
+		got, err := cfg.PoolMaxAge()
+		if c.ok && (err != nil || got != c.want) {
+			t.Errorf("PoolMaxAge(%q) = %v, %v; want %v", c.in, got, err, c.want)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("PoolMaxAge(%q) must be rejected", c.in)
+		}
+	}
+}

--- a/internal/driver/awsec2/create.go
+++ b/internal/driver/awsec2/create.go
@@ -197,7 +197,7 @@ func (d *Driver) launch(ctx context.Context, spec driver.CreateSpec, me, ami, ud
 }
 
 func tagList(spec driver.CreateSpec, me, name string) []map[string]string {
-	return []map[string]string{
+	tags := []map[string]string{
 		{"Key": "Name", "Value": name},
 		{"Key": TagManaged, "Value": "1"},
 		{"Key": TagUser, "Value": me},
@@ -206,6 +206,10 @@ func tagList(spec driver.CreateSpec, me, name string) []map[string]string {
 		{"Key": TagBranch, "Value": spec.Branch},
 		{"Key": TagCreated, "Value": time.Now().UTC().Format(time.RFC3339)},
 	}
+	if spec.PoolGen != "" {
+		tags = append(tags, map[string]string{"Key": TagPool, "Value": spec.PoolGen})
+	}
+	return tags
 }
 
 // archOf maps the instance type to arm64/amd64 (selects AMI + supervisor build).

--- a/internal/driver/awsec2/create_test.go
+++ b/internal/driver/awsec2/create_test.go
@@ -22,3 +22,24 @@ func TestTagListCarriesCreateTime(t *testing.T) {
 	}
 	t.Fatalf("tagList missing %s", TagCreated)
 }
+
+// The pool tag is what separates a warm member from a user session in every
+// view — a regular create must never carry it, a pool create always must.
+func TestTagListPoolGen(t *testing.T) {
+	spec := driver.CreateSpec{Name: "x", Repo: "/tmp/myrepo", Branch: "main"}
+	for _, tag := range tagList(spec, "me", "pier-x") {
+		if tag["Key"] == TagPool {
+			t.Fatalf("regular create carries %s=%q", TagPool, tag["Value"])
+		}
+	}
+	spec.PoolGen = "ab12cd34ef56"
+	for _, tag := range tagList(spec, "me", "pier-x") {
+		if tag["Key"] == TagPool {
+			if tag["Value"] != spec.PoolGen {
+				t.Fatalf("%s = %q, want %q", TagPool, tag["Value"], spec.PoolGen)
+			}
+			return
+		}
+	}
+	t.Fatalf("pool create missing %s", TagPool)
+}

--- a/internal/driver/awsec2/driver.go
+++ b/internal/driver/awsec2/driver.go
@@ -34,6 +34,8 @@ const (
 	TagBranch     = "pier:branch"
 	TagReady      = "pier:ready"   // create's last act: bootstrap done, attachable
 	TagCreated    = "pier:created" // RFC3339 create time; launch time resets on every resume
+	TagPool       = "pier:pool"    // warm-pool generation fingerprint; present = unclaimed member
+	TagClaim      = "pier:claim"   // claim nonce (tags have no CAS: written, then read back)
 	amiParamBase  = "/aws/service/canonical/ubuntu/server/24.04/stable/current/%s/hvm/ebs-gp3/ami-id"
 )
 
@@ -140,6 +142,8 @@ func (d *Driver) List(ctx context.Context) ([]driver.Session, error) {
 				if ts, err := time.Parse(time.RFC3339, t.Value); err == nil {
 					s.Created = ts
 				}
+			case TagPool:
+				s.PoolGen = t.Value
 			}
 		}
 		switch in.State {
@@ -197,7 +201,19 @@ func costNote(st driver.State, itype string) string {
 
 func (d *Driver) Resume(ctx context.Context, id string) error {
 	if _, err := d.aws(ctx, "ec2", "start-instances", "--instance-ids", id); err != nil {
-		return err
+		// A parking instance sits in `stopping` for up to a minute — the list
+		// already calls that parked, so resuming right after a park (or
+		// claiming a just-filled pool member) lands here. Wait out the stop
+		// and start again.
+		if !strings.Contains(err.Error(), "IncorrectInstanceState") {
+			return err
+		}
+		if _, werr := d.aws(ctx, "ec2", "wait", "instance-stopped", "--instance-ids", id); werr != nil {
+			return err
+		}
+		if _, err = d.aws(ctx, "ec2", "start-instances", "--instance-ids", id); err != nil {
+			return err
+		}
 	}
 	d.dropProbe(id) // the VM comes back on a fresh public IP
 	return d.waitSSH(ctx, id, 240*time.Second)

--- a/internal/driver/awsec2/pool.go
+++ b/internal/driver/awsec2/pool.go
@@ -1,0 +1,60 @@
+package awsec2
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/kerem-kaynak/pier/internal/driver"
+)
+
+// Claim converts a warm pool member into a named session, tags only. EC2 tag
+// writes have no compare-and-swap, so ownership is settled by nonce
+// read-back: write the nonce, wait a settle beat (covers a rival writing
+// between our write and our read), read it back — the later writer wins and
+// the earlier one sees a foreign nonce. The read-back also checks the pool
+// tag: deleting it is a winner's commit point, so a rival that finished the
+// race while we were writing leaves the member a live session our nonce
+// must not hijack. Claimers also spread across members by nonce hash, so two
+// concurrent claims rarely even meet on one instance.
+func (d *Driver) Claim(ctx context.Context, id string, spec driver.ClaimSpec) error {
+	if _, err := d.aws(ctx, "ec2", "create-tags", "--resources", id,
+		"--tags", "Key="+TagClaim+",Value="+spec.Nonce); err != nil {
+		return err
+	}
+	time.Sleep(time.Second)
+	out, err := d.aws(ctx, "ec2", "describe-tags",
+		"--filters", "Name=resource-id,Values="+id, "Name=key,Values="+TagClaim+","+TagPool,
+		"--query", "[Tags[?Key=='"+TagClaim+"'].Value|[0], Tags[?Key=='"+TagPool+"'].Value|[0]]",
+		"--output", "text")
+	if err != nil {
+		return err
+	}
+	f := strings.Fields(out) // "<nonce> <gen>"; a missing tag reads as None
+	if len(f) != 2 || f[1] == "None" {
+		// Someone committed: the member is their session now. Our claim tag
+		// pollutes it — delete it value-scoped (EC2 removes a Key+Value pair
+		// only when the value still matches, so a third writer's nonce
+		// survives us).
+		_, _ = d.aws(ctx, "ec2", "delete-tags", "--resources", id,
+			"--tags", "Key="+TagClaim+",Value="+spec.Nonce)
+		return driver.ErrClaimLost
+	}
+	if f[0] != spec.Nonce {
+		return driver.ErrClaimLost
+	}
+	// The created tag resets to now: the user's session begins at claim, and
+	// AGE reads the created tag (fill time would show a days-old "new" session).
+	if _, err := d.aws(ctx, "ec2", "create-tags", "--resources", id, "--tags",
+		"Key=Name,Value=pier-"+spec.Name,
+		"Key="+TagSession+",Value="+spec.Name,
+		"Key="+TagBranch+",Value="+spec.Branch,
+		"Key="+TagCreated+",Value="+time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return err
+	}
+	// Deleting the pool tag is the commit point: the member now lists as a
+	// regular session.
+	_, err = d.aws(ctx, "ec2", "delete-tags", "--resources", id,
+		"--tags", "Key="+TagPool, "Key="+TagClaim)
+	return err
+}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -11,6 +11,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,6 +44,7 @@ type Session struct {
 	InstanceType string    // provider machine type; feeds the TUI resize picker
 	Created      time.Time // session creation, not last boot — AGE must never go backward
 	CostNote     string    // honest money: "~$3-4/mo" parked, the type's hourly rate otherwise
+	PoolGen      string    // warm-pool generation fingerprint; non-empty = unclaimed pool member, not a user session
 }
 
 // Machine is one row in the TUI's resize picker: a curated instance type
@@ -65,7 +67,25 @@ type CreateSpec struct {
 	Image         string        // the repo's baked image ID; "" = stock (guarded cloud-init installs everything)
 	IdleTimeout   time.Duration // 0 = never auto-park
 	UnattendedCap time.Duration // 0 = no runaway cap
+	PoolGen       string        // non-empty: create a warm pool member (drivers add the pool tag/label; Name is the placeholder)
 	Progress      func(step string)
+}
+
+// ErrClaimLost: another claimer won this pool member — move on to the next
+// candidate.
+var ErrClaimLost = errors.New("pool member claimed by another process")
+
+// ClaimSpec names the session a warm pool member becomes.
+type ClaimSpec struct {
+	Name   string
+	Branch string
+	// Nonce is this claimer's unique token. Tags and labels have no
+	// compare-and-swap, so Claim writes the nonce, waits a settle beat, and
+	// reads it back: of two concurrent claimers the later write wins and the
+	// earlier one sees a foreign nonce (ErrClaimLost). This closes the
+	// same-user two-terminal race — it is not a security boundary; per-user
+	// namespacing is.
+	Nonce string
 }
 
 // BakeSpec describes one repo's image bake. Images are repo-specific: the
@@ -120,6 +140,13 @@ type Driver interface {
 	Resume(ctx context.Context, id string) error
 	Park(ctx context.Context, id string) error // client-initiated; normal parking is the VM's own shutdown
 	Destroy(ctx context.Context, id string) error
+
+	// Claim converts a warm pool member into a named session: nonce
+	// write + read-back (see ClaimSpec.Nonce), then name/branch rewrite;
+	// clearing the pool marker is the commit point, after which List reports
+	// a regular session. Tags/labels only — the caller Resumes and freshens
+	// the instance itself.
+	Claim(ctx context.Context, id string, spec ClaimSpec) error
 
 	// Resize changes the instance size (vertical scaling). Providers only
 	// allow this on stopped instances, and park is exactly a stop — so a

--- a/internal/driver/gcpgce/create.go
+++ b/internal/driver/gcpgce/create.go
@@ -141,6 +141,10 @@ func (d *Driver) launch(ctx context.Context, spec driver.CreateSpec, me, id, pub
 		MetaBranch + "=" + spec.Branch,
 		MetaUser + "=" + me,
 	}, ",")
+	labels := LabelManaged + "=1," + LabelUser + "=" + labelValue(me)
+	if spec.PoolGen != "" {
+		labels += "," + LabelPool + "=" + spec.PoolGen
+	}
 	args := []string{"compute", "instances", "create", id,
 		"--zone", d.Zone,
 		"--machine-type", d.MachineType,
@@ -148,7 +152,7 @@ func (d *Driver) launch(ctx context.Context, spec driver.CreateSpec, me, id, pub
 		"--boot-disk-type", "pd-balanced",
 		"--no-service-account", "--no-scopes",
 		"--tags", NetworkTag,
-		"--labels", LabelManaged + "=1," + LabelUser + "=" + labelValue(me),
+		"--labels", labels,
 		"--metadata-from-file", "user-data=" + udPath,
 		"--metadata", meta,
 		"--format", "value(name)",

--- a/internal/driver/gcpgce/driver.go
+++ b/internal/driver/gcpgce/driver.go
@@ -49,10 +49,13 @@ const (
 	LabelUser     = "pier-user"
 	LabelReady    = "pier-ready"    // create's last act: bootstrap done, attachable
 	LabelDeleting = "pier-deleting" // destroy's first act: the delete itself takes a minute+
+	LabelPool     = "pier-pool"     // warm-pool generation fingerprint (hex, label-safe); present = unclaimed member
+	LabelClaim    = "pier-claim"    // claim nonce (labels have no client CAS: written, then read back)
 	MetaSession   = "pier-session"
 	MetaRepo      = "pier-repo"
 	MetaBranch    = "pier-branch"
-	MetaUser      = "pier-user" // full principal; the label form is lossy
+	MetaUser      = "pier-user"    // full principal; the label form is lossy
+	MetaCreated   = "pier-created" // RFC3339; set at claim so AGE starts then, not at fill
 
 	stockImageProject = "ubuntu-os-cloud"
 	stockImageFamily  = "ubuntu-2404-lts-%s" // amd64 | arm64
@@ -178,8 +181,13 @@ func (d *Driver) List(ctx context.Context) ([]driver.Session, error) {
 				s.Branch = m.Value
 			case MetaUser:
 				owner = m.Value
+			case MetaCreated:
+				if ts, err := time.Parse(time.RFC3339, m.Value); err == nil {
+					s.Created = ts
+				}
 			}
 		}
+		s.PoolGen = in.Labels[LabelPool]
 		// The label filter is lossy (folded charset); the metadata principal
 		// is exact. A fold collision must not leak someone else's session.
 		if owner != me {
@@ -209,9 +217,12 @@ func (d *Driver) List(ctx context.Context) ([]driver.Session, error) {
 			}
 		}
 		// creationTimestamp survives stop/start (unlike EC2 launch time), so
-		// AGE never goes backward and no created tag is needed.
-		if ts, err := time.Parse(time.RFC3339, in.CreationTimestamp); err == nil {
-			s.Created = ts
+		// AGE never goes backward and no created tag is needed — except for
+		// claimed pool members, whose session began at claim (MetaCreated).
+		if s.Created.IsZero() {
+			if ts, err := time.Parse(time.RFC3339, in.CreationTimestamp); err == nil {
+				s.Created = ts
+			}
 		}
 		s.CostNote = costNote(s.State, s.InstanceType)
 		sessions = append(sessions, s)
@@ -242,7 +253,18 @@ func costNote(st driver.State, machineType string) string {
 
 func (d *Driver) Resume(ctx context.Context, id string) error {
 	if _, err := d.gcloud(ctx, "compute", "instances", "start", id, "--zone", d.Zone); err != nil {
-		return err
+		// A parking instance sits in STOPPING for a minute — the list already
+		// calls that parked, so resuming right after a park (or claiming a
+		// just-filled pool member) lands here. Stopping again is idempotent
+		// and blocks until TERMINATED (the same trick Resize plays); then
+		// start for real. On any other failure the stop fails too and the
+		// original error stands.
+		if _, serr := d.gcloud(ctx, "compute", "instances", "stop", id, "--zone", d.Zone); serr != nil {
+			return err
+		}
+		if _, err = d.gcloud(ctx, "compute", "instances", "start", id, "--zone", d.Zone); err != nil {
+			return err
+		}
 	}
 	return d.waitSSH(ctx, id, 300*time.Second)
 }

--- a/internal/driver/gcpgce/pool.go
+++ b/internal/driver/gcpgce/pool.go
@@ -1,0 +1,61 @@
+package gcpgce
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/kerem-kaynak/pier/internal/driver"
+)
+
+// Claim converts a warm pool member into a named session, labels and
+// metadata only (GCE instances can't be renamed — the instance name is just
+// an ID, and the placeholder name baked into it is cosmetic). Label writes
+// are last-writer-wins, so ownership is settled by nonce read-back: write
+// the nonce, wait a settle beat (covers a rival writing between our write
+// and our read), read it back — the later writer wins and the earlier one
+// sees a foreign nonce. The read-back also checks the pool label: removing
+// it is a winner's commit point, so a rival that finished the race while we
+// were writing leaves the member a live session our nonce must not hijack.
+// Claimers also spread across members by nonce hash, so two concurrent
+// claims rarely even meet on one instance.
+func (d *Driver) Claim(ctx context.Context, id string, spec driver.ClaimSpec) error {
+	if _, err := d.gcloud(ctx, "compute", "instances", "add-labels", id,
+		"--zone", d.Zone, "--labels", LabelClaim+"="+spec.Nonce); err != nil {
+		return err
+	}
+	time.Sleep(time.Second)
+	out, err := d.gcloud(ctx, "compute", "instances", "describe", id,
+		"--zone", d.Zone, "--format", "value(labels."+LabelClaim+",labels."+LabelPool+")")
+	if err != nil {
+		return err
+	}
+	// "<nonce>\t<gen>"; a missing label reads as empty.
+	nonce, pool, _ := strings.Cut(out, "\t")
+	if pool == "" {
+		// Someone committed: the member is their session now. Our claim label
+		// pollutes it — remove it (not value-scoped on GCE, but any claim
+		// label on a committed member is leftover race debris regardless of
+		// whose nonce it holds).
+		_, _ = d.gcloud(ctx, "compute", "instances", "remove-labels", id,
+			"--zone", d.Zone, "--labels", LabelClaim)
+		return driver.ErrClaimLost
+	}
+	if nonce != spec.Nonce {
+		return driver.ErrClaimLost
+	}
+	// add-metadata overwrites existing keys. MetaCreated starts AGE at claim:
+	// creationTimestamp would show the member's fill time on a "new" session.
+	// ValidateNames' charset keeps the comma-joined values safe.
+	if _, err := d.gcloud(ctx, "compute", "instances", "add-metadata", id,
+		"--zone", d.Zone, "--metadata",
+		MetaSession+"="+spec.Name+","+MetaBranch+"="+spec.Branch+","+
+			MetaCreated+"="+time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return err
+	}
+	// Removing the pool label is the commit point: the member now lists as a
+	// regular session.
+	_, err = d.gcloud(ctx, "compute", "instances", "remove-labels", id,
+		"--zone", d.Zone, "--labels", LabelPool+","+LabelClaim)
+	return err
+}

--- a/internal/driver/payload/freshen.go
+++ b/internal/driver/payload/freshen.go
@@ -1,0 +1,87 @@
+package payload
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kerem-kaynak/pier/internal/driver"
+)
+
+// --- pool claim freshen --------------------------------------------------------
+// A warm pool member already carries everything slow: harnesses, supervisor,
+// the repo's history, a completed .pier-setup.sh. Claiming it means making
+// what's cheap-but-stale current again — this script is that step. It runs on
+// the just-resumed member (a boot: the tmux server is always gone, /tmp is
+// clean) after the same cargo pushes as create, minus supervisor + user-data.
+
+const freshenTmpl = `#!/usr/bin/env bash
+# pier freshen — runs at claim, as agent, on a just-resumed warm pool member.
+set -euo pipefail
+
+tar -xf /tmp/pier-files.tar -C "$HOME" --strip-components=1 home 2>/dev/null || true
+set -a; . "$HOME/.config/pier/env" 2>/dev/null || true; set +a
+
+cd "$HOME/work/{{REPO}}"
+{{GITCONFIG}}
+# The transfer decision is re-made at claim — auth can change between fill and
+# claim (token added or revoked), and the origin URL follows it.
+if [ -n '{{ORIGIN}}' ]; then git remote set-url origin '{{ORIGIN}}' 2>/dev/null || git remote add origin '{{ORIGIN}}'; fi
+case '{{ORIGIN}}' in git@*|ssh://*) mkdir -p "$HOME/.ssh" && ssh-keyscan github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null || true ;; esac
+{ command -v gh >/dev/null && [ -n "${GH_TOKEN:-}" ] && gh auth setup-git >/dev/null 2>&1; } || true
+case '{{MODE}}' in
+  origin) git fetch -q --no-tags origin {{SHA}} ;;
+  thin)   git fetch -q --no-tags origin && git fetch -q /tmp/pier.bundle {{EXPORTREF}} ;;
+  *)      git fetch -q /tmp/pier.bundle {{EXPORTREF}} ;;
+esac
+# -f discards the member's fill-time tracked state; untracked setup artifacts
+# (node_modules, caches — the warmth being claimed) survive. The placeholder
+# branch dies once the real one exists (-qD fails harmlessly if checked out).
+git checkout -qf -B '{{BRANCH}}' {{SHA}}
+git reset -q --hard {{SHA}}
+git branch -qD '{{OLDBRANCH}}' 2>/dev/null || true
+# Uncommitted edits to tracked files, exactly as the laptop had them (a
+# failed apply fails the claim — better than silently missing work).
+if [ -f /tmp/pier-dirty.patch ]; then git apply /tmp/pier-dirty.patch; fi
+tar -xf /tmp/pier-files.tar -C . --strip-components=1 repo 2>/dev/null || true
+
+# Cosmetic: prompts show the session, not the pool placeholder.
+sudo hostnamectl set-hostname '{{HOSTNAME}}' 2>/dev/null || true
+
+` + tmuxEnsure + setupWindow + `
+rm -f /tmp/pier.bundle /tmp/pier-files.tar /tmp/pier-dirty.patch /tmp/pier-freshen.sh
+echo freshened
+`
+
+// BuildFreshen assembles the claim-time cargo that turns a warm pool member
+// into the requested session: refreshed secrets (they rotate), the repo
+// update (the same origin/thin/full decision as create — the member's
+// fill-time checkout makes origin fetches incremental), the dirty patch, and
+// the freshen script. oldBranch is the member's placeholder branch. The
+// supervisor timeouts are deliberately NOT reset here: fill leaves a 2m idle
+// leash that could self-park the member mid-push, so the claim flow resets
+// the conf via Exec right after Resume, before any of this lands.
+func BuildFreshen(ctx context.Context, dir string, spec driver.CreateSpec, oldBranch string, manifest []string, env map[string]string, progress func(string)) (*Payload, error) {
+	p, mode, sha, origin, err := buildCommon(ctx, dir, spec, manifest, env, progress)
+	if err != nil {
+		return nil, err
+	}
+	script := strings.NewReplacer(
+		"{{REPO}}", filepath.Base(spec.Repo),
+		"{{BRANCH}}", spec.Branch,
+		"{{OLDBRANCH}}", oldBranch,
+		"{{GITCONFIG}}", gitIdentity(spec.Repo),
+		"{{MODE}}", mode,
+		"{{SHA}}", sha,
+		"{{ORIGIN}}", origin,
+		"{{EXPORTREF}}", exportRef(spec.Name),
+		"{{HOSTNAME}}", Sanitize(spec.Name),
+	).Replace(freshenTmpl)
+	fp := filepath.Join(dir, "pier-freshen.sh")
+	if err := os.WriteFile(fp, []byte(script), 0o755); err != nil {
+		return nil, err
+	}
+	p.Pushes = append([]Push{{fp, "/tmp/pier-freshen.sh"}}, p.Pushes...)
+	return p, nil
+}

--- a/internal/driver/payload/payload.go
+++ b/internal/driver/payload/payload.go
@@ -43,11 +43,35 @@ type Payload struct {
 // VM fetches the repo from GitHub directly (~100x faster) and the laptop
 // sends at most a thin local-delta bundle.
 func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor []byte, manifest []string, env map[string]string, progress func(string)) (*Payload, error) {
-	sha, err := gitOut(spec.Repo, "rev-parse", "--verify", baseRef(spec)+"^{commit}")
+	p, mode, sha, origin, err := buildCommon(ctx, dir, spec, manifest, env, progress)
 	if err != nil {
-		return nil, fmt.Errorf("base ref %q not found", baseRef(spec))
+		return nil, err
 	}
-	mode, origin := originInfo(spec.Repo, sha)
+	supPath := filepath.Join(dir, "pier-supervisor")
+	if err := os.WriteFile(supPath, supervisor, 0o755); err != nil {
+		return nil, err
+	}
+	bootPath := filepath.Join(dir, "pier-bootstrap.sh")
+	if err := os.WriteFile(bootPath, []byte(renderBootstrap(spec, mode, sha, origin)), 0o755); err != nil {
+		return nil, err
+	}
+	p.Pushes = append([]Push{
+		{supPath, "/tmp/pier-supervisor"},
+		{bootPath, "/tmp/pier-bootstrap.sh"},
+	}, p.Pushes...)
+	return p, nil
+}
+
+// buildCommon resolves the repo-transfer decision and writes the cargo that
+// create and pool-claim freshen share — files tar, bundle, dirty patch — into
+// dir. Callers prepend their script pushes, keeping the biggest cargo last so
+// its meter is the wait the user watches.
+func buildCommon(ctx context.Context, dir string, spec driver.CreateSpec, manifest []string, env map[string]string, progress func(string)) (p *Payload, mode, sha, origin string, err error) {
+	sha, err = gitOut(spec.Repo, "rev-parse", "--verify", baseRef(spec)+"^{commit}")
+	if err != nil {
+		return nil, "", "", "", fmt.Errorf("base ref %q not found", baseRef(spec))
+	}
+	mode, origin = originInfo(spec.Repo, sha)
 	forwardAgent := false
 	why := "no github origin has the base"
 	if mode != "full" {
@@ -76,7 +100,7 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 		case errors.Is(err, errEmptyBundle) && mode == "thin":
 			mode, bundle = "origin", ""
 		case err != nil:
-			return nil, fmt.Errorf("bundling %s: %w", spec.Repo, err)
+			return nil, "", "", "", fmt.Errorf("bundling %s: %w", spec.Repo, err)
 		}
 	}
 	// Dirty tracked state travels only when the session's base IS the
@@ -84,12 +108,12 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 	// today's edits onto it would be a lie about what that base contained.
 	patch := ""
 	if head, _ := gitOut(spec.Repo, "rev-parse", "HEAD"); head == sha {
-		p := filepath.Join(dir, "pier-dirty.patch")
-		switch ok, err := dirtyPatch(spec.Repo, p); {
+		pp := filepath.Join(dir, "pier-dirty.patch")
+		switch ok, err := dirtyPatch(spec.Repo, pp); {
 		case err != nil:
-			return nil, err
+			return nil, "", "", "", err
 		case ok:
-			patch = p
+			patch = pp
 		}
 	}
 	setupSrc, warn := setupScriptOverride(spec.Repo)
@@ -98,7 +122,7 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 	}
 	filesTar := filepath.Join(dir, "pier-files.tar")
 	if err := buildFilesTar(filesTar, manifest, spec.Repo, env, setupSrc); err != nil {
-		return nil, err
+		return nil, "", "", "", err
 	}
 	if miss := envFilesNotCarried(spec.Repo, pierIncludeFiles(spec.Repo)); len(miss) > 0 {
 		name := miss[0]
@@ -107,19 +131,9 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 		}
 		progress("not carrying " + name + " — env files travel only when .pier-include lists them")
 	}
-	supPath := filepath.Join(dir, "pier-supervisor")
-	if err := os.WriteFile(supPath, supervisor, 0o755); err != nil {
-		return nil, err
-	}
-	bootPath := filepath.Join(dir, "pier-bootstrap.sh")
-	if err := os.WriteFile(bootPath, []byte(renderBootstrap(spec, mode, sha, origin)), 0o755); err != nil {
-		return nil, err
-	}
 
-	p := &Payload{ForwardAgent: forwardAgent}
+	p = &Payload{ForwardAgent: forwardAgent}
 	p.Pushes = []Push{
-		{supPath, "/tmp/pier-supervisor"},
-		{bootPath, "/tmp/pier-bootstrap.sh"},
 		{filesTar, "/tmp/pier-files.tar"},
 	}
 	switch mode {
@@ -140,7 +154,7 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 	if names := OAuthRemotes(home, spec.Repo); len(names) > 0 {
 		p.Notes = append(p.Notes, "mcp "+strings.Join(names, ", ")+": one-time oauth — `pier mcp login "+spec.Name+"` when it's up")
 	}
-	return p, nil
+	return p, mode, sha, origin, nil
 }
 
 func baseRef(spec driver.CreateSpec) string {

--- a/internal/driver/payload/payload_test.go
+++ b/internal/driver/payload/payload_test.go
@@ -66,11 +66,11 @@ func TestValidateNames(t *testing.T) {
 }
 
 func TestDurConf(t *testing.T) {
-	if got := durConf(0); got != "never" {
-		t.Errorf("durConf(0) = %q, want never", got)
+	if got := DurConf(0); got != "never" {
+		t.Errorf("DurConf(0) = %q, want never", got)
 	}
-	if got := durConf(30 * time.Minute); got != "30m0s" {
-		t.Errorf("durConf(30m) = %q, want 30m0s", got)
+	if got := DurConf(30 * time.Minute); got != "30m0s" {
+		t.Errorf("DurConf(30m) = %q, want 30m0s", got)
 	}
 }
 

--- a/internal/driver/payload/scripts.go
+++ b/internal/driver/payload/scripts.go
@@ -88,12 +88,14 @@ func RenderUserData(spec driver.CreateSpec, pubkey string) string {
 	return strings.NewReplacer(
 		"{{HOSTNAME}}", Sanitize(spec.Name),
 		"{{PUBKEY}}", pubkey,
-		"{{IDLE}}", durConf(spec.IdleTimeout),
-		"{{CAP}}", durConf(spec.UnattendedCap),
+		"{{IDLE}}", DurConf(spec.IdleTimeout),
+		"{{CAP}}", DurConf(spec.UnattendedCap),
 	).Replace(userDataTmpl)
 }
 
-func durConf(d time.Duration) string {
+// DurConf renders a timeout the way /etc/pier/supervisor.conf spells it.
+// Exported for the pool claim flow, which rewrites that file over ssh.
+func DurConf(d time.Duration) string {
 	if d <= 0 {
 		return "never"
 	}
@@ -101,6 +103,42 @@ func durConf(d time.Duration) string {
 }
 
 // --- bootstrap ----------------------------------------------------------------
+// The tmux-server start and the async setup window are shared with the pool
+// freshen script (freshen.go): a claimed member resumes from parked — a boot,
+// so the tmux server is always gone — and re-runs setup to catch drift.
+
+const tmuxEnsure = `# SSH_AUTH_SOCK points at the attach-refreshed symlink (dangling until the
+# first attach forwards an agent; harmless when it never does).
+# The server starts through sudo because group membership is snapshotted at
+# login: on a stock image cloud-init's "usermod -aG docker agent" lands after
+# this ssh session began, so a server started directly here would carry a
+# pre-docker group set for its whole life — and every window forks from the
+# server, so .pier-setup.sh and the user's shells all get docker.sock denied.
+# sudo re-runs initgroups, picking up /etc/group as it stands after the
+# cloud-init wait above.
+tmux has-session -t main 2>/dev/null || sudo -u agent tmux new-session -d -s main -e "SSH_AUTH_SOCK=$HOME/.ssh/agent.sock" -c "$HOME/work/{{REPO}}"
+`
+
+const setupWindow = `# Background setup, after checkout + patch + .pier-include extras are all in
+# place: the repo's .pier-setup.sh, unless a PIER_SETUP_SCRIPT override rode
+# the tar (outer double quotes expand $setup now, into the single-quoted
+# bash -c; \$ defers the rest to run time). The outcome must be impossible to
+# miss — a failed setup used to vanish with its window: ~/.pier-setup.status
+# holds "running" then the exit code (the supervisor beacons it to ls/TUI),
+# the log's last line says done/FAILED, and a failed window renames to
+# setup-failed and stays open instead of closing. The rename targets its own
+# pane id: with a client attached, a bare rename-window can resolve "current
+# window" to the attached client's window and mislabel the user's shell.
+setup=./.pier-setup.sh
+if [ -f "$HOME/.config/pier/setup.sh" ]; then setup="$HOME/.config/pier/setup.sh"; fi
+# Presence is the signal, not the exec bit: git only carries +x when the
+# author remembered chmod, and gating on -x skipped a committed 0644
+# .pier-setup.sh with no trace — the one silent failure setup promises not
+# to have. bash runs it either way.
+if [ -f "$setup" ]; then
+  tmux new-window -d -t main -n setup "bash -c 'set -a; . ~/.config/pier/env 2>/dev/null; set +a; cd ~/work/{{REPO}} || exit 1; echo running > ~/.pier-setup.status; bash $setup 2>&1 | tee ~/.pier-setup.log; c=\${PIPESTATUS[0]}; echo \$c > ~/.pier-setup.status; if [ \$c -eq 0 ]; then echo \"pier setup: done\" >> ~/.pier-setup.log; else echo \"pier setup: FAILED (exit \$c)\" | tee -a ~/.pier-setup.log; tmux rename-window -t \$TMUX_PANE setup-failed; exec sleep infinity; fi'"
+fi
+`
 
 const bootstrapTmpl = `#!/usr/bin/env bash
 # pier bootstrap — runs once, as agent, on the fresh instance.
@@ -170,36 +208,7 @@ if [ ! -f "$HOME/.tmux.conf" ]; then
   printf 'set -g mouse on\nset -g history-limit 50000\nset -g focus-events on\n' > "$HOME/.tmux.conf"
 fi
 
-# SSH_AUTH_SOCK points at the attach-refreshed symlink (dangling until the
-# first attach forwards an agent; harmless when it never does).
-# The server starts through sudo because group membership is snapshotted at
-# login: on a stock image cloud-init's "usermod -aG docker agent" lands after
-# this ssh session began, so a server started directly here would carry a
-# pre-docker group set for its whole life — and every window forks from the
-# server, so .pier-setup.sh and the user's shells all get docker.sock denied.
-# sudo re-runs initgroups, picking up /etc/group as it stands after the
-# cloud-init wait above.
-tmux has-session -t main 2>/dev/null || sudo -u agent tmux new-session -d -s main -e "SSH_AUTH_SOCK=$HOME/.ssh/agent.sock" -c "$HOME/work/{{REPO}}"
-# Background setup, after checkout + patch + .pier-include extras are all in
-# place: the repo's .pier-setup.sh, unless a PIER_SETUP_SCRIPT override rode
-# the tar (outer double quotes expand $setup now, into the single-quoted
-# bash -c; \$ defers the rest to run time). The outcome must be impossible to
-# miss — a failed setup used to vanish with its window: ~/.pier-setup.status
-# holds "running" then the exit code (the supervisor beacons it to ls/TUI),
-# the log's last line says done/FAILED, and a failed window renames to
-# setup-failed and stays open instead of closing. The rename targets its own
-# pane id: with a client attached, a bare rename-window can resolve "current
-# window" to the attached client's window and mislabel the user's shell.
-setup=./.pier-setup.sh
-if [ -f "$HOME/.config/pier/setup.sh" ]; then setup="$HOME/.config/pier/setup.sh"; fi
-# Presence is the signal, not the exec bit: git only carries +x when the
-# author remembered chmod, and gating on -x skipped a committed 0644
-# .pier-setup.sh with no trace — the one silent failure setup promises not
-# to have. bash runs it either way.
-if [ -f "$setup" ]; then
-  tmux new-window -d -t main -n setup "bash -c 'set -a; . ~/.config/pier/env 2>/dev/null; set +a; cd ~/work/{{REPO}} || exit 1; echo running > ~/.pier-setup.status; bash $setup 2>&1 | tee ~/.pier-setup.log; c=\${PIPESTATUS[0]}; echo \$c > ~/.pier-setup.status; if [ \$c -eq 0 ]; then echo \"pier setup: done\" >> ~/.pier-setup.log; else echo \"pier setup: FAILED (exit \$c)\" | tee -a ~/.pier-setup.log; tmux rename-window -t \$TMUX_PANE setup-failed; exec sleep infinity; fi'"
-fi
-
+` + tmuxEnsure + setupWindow + `
 # Attach gates on this marker: nobody lands in a half-set-up session. Written
 # after the repo checkout and tmux session exist; deliberately NOT after
 # .pier-setup.sh, which runs async in its tmux window.
@@ -210,27 +219,27 @@ echo bootstrapped
 `
 
 func renderBootstrap(spec driver.CreateSpec, mode, sha, origin string) string {
-	var gitcfg []string
-	line := func(args ...string) {
-		out, err := gitOut(spec.Repo, args...)
-		if err == nil && out != "" && !strings.Contains(out, "'") {
-			switch args[len(args)-1] {
-			case "user.name":
-				gitcfg = append(gitcfg, "git config user.name '"+out+"'")
-			case "user.email":
-				gitcfg = append(gitcfg, "git config user.email '"+out+"'")
-			}
-		}
-	}
-	line("config", "user.name")
-	line("config", "user.email")
 	return strings.NewReplacer(
 		"{{REPO}}", filepath.Base(spec.Repo),
 		"{{BRANCH}}", spec.Branch,
-		"{{GITCONFIG}}", strings.Join(gitcfg, "\n"),
+		"{{GITCONFIG}}", gitIdentity(spec.Repo),
 		"{{MODE}}", mode,
 		"{{SHA}}", sha,
 		"{{ORIGIN}}", origin,
 		"{{EXPORTREF}}", exportRef(spec.Name),
 	).Replace(bootstrapTmpl)
+}
+
+// gitIdentity replicates the laptop's git author identity as config lines
+// spliced into the bootstrap/freshen scripts. Values containing a quote are
+// dropped rather than escaped — the scripts single-quote them.
+func gitIdentity(repo string) string {
+	var gitcfg []string
+	for _, key := range []string{"user.name", "user.email"} {
+		out, err := gitOut(repo, "config", key)
+		if err == nil && out != "" && !strings.Contains(out, "'") {
+			gitcfg = append(gitcfg, "git config "+key+" '"+out+"'")
+		}
+	}
+	return strings.Join(gitcfg, "\n")
 }

--- a/internal/pool/claim.go
+++ b/internal/pool/claim.go
@@ -1,0 +1,170 @@
+package pool
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/kerem-kaynak/pier/internal/driver"
+	"github.com/kerem-kaynak/pier/internal/driver/payload"
+)
+
+// Claim tries to turn a warm pool member into the requested session:
+// tag-claim it (nonce read-back settles races), resume it, freshen it —
+// secrets re-pushed, repo moved to the requested branch/base, dirty patch
+// applied, the user's supervisor timeouts restored, setup re-run async to
+// catch drift since fill. Returns (nil, nil) when no member is claimable or
+// a freshen fails (the member is destroyed: its state is untrusted) — either
+// way the caller falls back to a fresh create.
+func Claim(ctx context.Context, p Params, sessions []driver.Session, name, branch, baseRef string) (*driver.Session, error) {
+	progress := p.progress()
+	// The create path validates names inside Create; the claim path writes
+	// them straight into tags and the freshen script, so it validates here —
+	// before anything touches the provider.
+	if err := payload.ValidateNames(driver.CreateSpec{Name: name, Repo: p.RepoRoot, Branch: branch, BaseRef: baseRef}); err != nil {
+		return nil, err
+	}
+	plan := Reconcile(Members(sessions, filepath.Base(p.RepoRoot)), p.Size, p.Gen, p.MaxAge, time.Now())
+	if len(plan.Ready) == 0 {
+		return nil, nil
+	}
+	nonce, err := newNonce()
+	if err != nil {
+		return nil, err
+	}
+	var member *driver.Session
+	for _, i := range pickOrder(len(plan.Ready), nonce) {
+		m := plan.Ready[i]
+		switch err := p.Driver.Claim(ctx, m.ID, driver.ClaimSpec{Name: name, Branch: branch, Nonce: nonce}); {
+		case errors.Is(err, driver.ErrClaimLost):
+			continue
+		case err != nil:
+			// A pool accelerates, never gates: a member destroyed under us, a
+			// throttled API, a label CAS conflict — skip the candidate; when
+			// none work, the caller creates fresh.
+			progress("claim of " + m.Name + " failed (" + err.Error() + ") — skipping")
+			continue
+		}
+		member = &m
+		break
+	}
+	if member == nil {
+		return nil, nil
+	}
+	progress(fmt.Sprintf("claimed warm member %s — resuming", member.Name))
+	if err := freshen(ctx, p, member, name, branch, baseRef); err != nil {
+		progress("freshen failed (" + err.Error() + ")")
+		progress("destroying the member — its state is untrusted — and creating fresh")
+		if derr := p.Driver.Destroy(context.WithoutCancel(ctx), member.ID); derr != nil {
+			progress("destroy failed too (" + derr.Error() + ") — check `pier pool` for a leftover member")
+		}
+		return nil, nil
+	}
+	return &driver.Session{
+		ID: member.ID, Name: name, Repo: filepath.Base(p.RepoRoot), Branch: branch,
+		User: member.User, Driver: p.Driver.Name(), State: driver.StateRunning,
+		Created: time.Now(), InstanceType: member.InstanceType,
+	}, nil
+}
+
+func freshen(ctx context.Context, p Params, member *driver.Session, name, branch, baseRef string) error {
+	progress := p.progress()
+	// Replacing FillLeash with the user's timeouts is the first act on the
+	// live member — inside the resume goroutine, so a slow payload build
+	// can't hand the still-leashed supervisor two idle minutes to park the
+	// member back mid-claim.
+	unleash := fmt.Sprintf(
+		"sudo sed -i 's/^idle_timeout=.*/idle_timeout=%s/; s/^unattended_cap=.*/unattended_cap=%s/' /etc/pier/supervisor.conf",
+		payload.DurConf(p.IdleTimeout), payload.DurConf(p.UnattendedCap))
+	// Resume and local payload prep overlap, the same trick create plays with
+	// the boot: claim latency is the whole point of the pool.
+	resumed := make(chan error, 1)
+	go func() {
+		if err := p.Driver.Resume(ctx, member.ID); err != nil {
+			resumed <- err
+			return
+		}
+		_, err := p.Driver.Exec(ctx, member.ID, unleash)
+		resumed <- err
+	}()
+
+	work, err := os.MkdirTemp("", "pier-claim-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(work)
+	spec := driver.CreateSpec{
+		Name: name, Repo: p.RepoRoot, Branch: branch, BaseRef: baseRef,
+		IdleTimeout: p.IdleTimeout, UnattendedCap: p.UnattendedCap,
+	}
+	pl, plErr := payload.BuildFreshen(ctx, work, spec, member.Name, p.Manifest, p.SessionEnv, progress)
+	if err := <-resumed; err != nil {
+		return err
+	}
+	if plErr != nil {
+		return plErr
+	}
+
+	// SSHTarget is the driver contract for features that manage their own
+	// ssh/scp processes — the same seam pier proxy rides.
+	opts, dest, err := p.Driver.SSHTarget(ctx, member.ID)
+	if err != nil {
+		return err
+	}
+	for _, n := range pl.Notes {
+		progress(n)
+	}
+	for _, push := range pl.Pushes {
+		if err := scpTo(ctx, opts, dest, push.Local, push.Remote); err != nil {
+			if ctx.Err() != nil {
+				return err
+			}
+			// One retry: tunnels drop right as a just-started instance
+			// settles, exactly as during create.
+			progress("push interrupted — retrying")
+			time.Sleep(2 * time.Second)
+			if err := scpTo(ctx, opts, dest, push.Local, push.Remote); err != nil {
+				return err
+			}
+		}
+	}
+	progress("freshening: branch, secrets, setup re-run")
+	var extra []string
+	if pl.ForwardAgent {
+		extra = []string{"-A"}
+	}
+	if out, err := sshRun(ctx, opts, extra, dest, "bash /tmp/pier-freshen.sh"); err != nil {
+		return fmt.Errorf("freshen: %w\n%s", err, out)
+	}
+	return nil
+}
+
+func scpTo(ctx context.Context, opts []string, dest, local, remote string) error {
+	args := slices.Concat(opts, []string{local, dest + ":" + remote})
+	cmd := exec.CommandContext(ctx, "scp", args...)
+	// scp draws its progress meter only when stdout is a terminal, same as
+	// the drivers' pushes.
+	cmd.Stdout = os.Stdout
+	var errb bytes.Buffer
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("scp %s -> %s: %s", local, dest, strings.TrimSpace(errb.String()))
+	}
+	return nil
+}
+
+func sshRun(ctx context.Context, opts, extra []string, dest, script string) (string, error) {
+	args := slices.Concat(opts, extra, []string{dest, script})
+	out, err := exec.CommandContext(ctx, "ssh", args...).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("ssh %s: %s", dest, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/pool/fill.go
+++ b/internal/pool/fill.go
@@ -1,0 +1,140 @@
+package pool
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kerem-kaynak/pier/internal/driver"
+)
+
+// Fill reconciles one repo's pool to Params.Size: stale members recycle,
+// missing ones get created, set up, and parked — one at a time; a fill is
+// background work, and serial keeps quota pressure and progress readable.
+// A member is created exactly like a session (same Create, same payload,
+// same async .pier-setup.sh) under a placeholder name, except its supervisor
+// runs on FillLeash — if this process dies, the member still self-parks
+// shortly after setup finishes instead of idling at full price.
+func Fill(ctx context.Context, p Params) error {
+	progress := p.progress()
+	sessions, err := p.Driver.List(ctx)
+	if err != nil {
+		return err
+	}
+	repo := filepath.Base(p.RepoRoot)
+	plan := Reconcile(Members(sessions, repo), p.Size, p.Gen, p.MaxAge, time.Now())
+	// These destroys act on a List snapshot seconds old. A claim committing in
+	// that window turns a member into a session this loop would still destroy —
+	// but claims only take Ready members and this loop only stale ones, so the
+	// two disagree about a member only across a re-bake racing a create. Known,
+	// accepted: the claimer fails loudly and falls back to a fresh create.
+	for _, m := range plan.Stale {
+		progress("recycling stale member " + m.Name)
+		if err := p.Driver.Destroy(ctx, m.ID); err != nil {
+			return err
+		}
+	}
+	if plan.Fill == 0 {
+		progress(fmt.Sprintf("pool %s is full (%d ready, %d filling)", repo, len(plan.Ready), plan.InFlight))
+		return nil
+	}
+	// Quota gate, conservative: at least 2 vCPUs per member. Pools must not
+	// eat the headroom real sessions need; an unreadable quota is not fatal —
+	// the create itself fails loudly on the provider's limit.
+	if q, err := p.Driver.Headroom(ctx); err == nil && q.Limit > 0 && q.Limit-q.Used < 2*plan.Fill {
+		return fmt.Errorf("filling %d member(s) needs more vCPU headroom than %s has — raise the quota or shrink the pool",
+			plan.Fill, q.Detail)
+	}
+	hasSetup := len(SetupScript(p.RepoRoot)) > 0
+	for i := range plan.Fill {
+		progress(fmt.Sprintf("filling member %d/%d", i+1, plan.Fill))
+		if err := fillOne(ctx, p, hasSetup); err != nil {
+			return err
+		}
+	}
+	progress(fmt.Sprintf("pool %s is full (%d ready)", repo, len(plan.Ready)+plan.Fill))
+	return nil
+}
+
+func fillOne(ctx context.Context, p Params, hasSetup bool) error {
+	name, err := placeholderName(p.RepoRoot)
+	if err != nil {
+		return err
+	}
+	sess, err := p.Driver.Create(ctx, driver.CreateSpec{
+		Name:          name,
+		Repo:          p.RepoRoot,
+		Branch:        name, // placeholder; claim's freshen replaces it
+		Image:         p.Image,
+		IdleTimeout:   FillLeash,
+		UnattendedCap: p.UnattendedCap,
+		PoolGen:       p.Gen,
+		Progress:      p.progress(),
+	})
+	if err != nil {
+		return err
+	}
+	if hasSetup {
+		p.progress()("waiting for .pier-setup.sh — a member is only warm once setup finished")
+		if err := waitSetup(ctx, p, sess.ID); err != nil {
+			// An unfinished setup is exactly what the pool exists to avoid:
+			// destroy rather than park a member that would claim cold.
+			p.progress()("destroying the failed member")
+			_ = p.Driver.Destroy(context.WithoutCancel(ctx), sess.ID)
+			return err
+		}
+	}
+	p.progress()("parking " + name)
+	return p.Driver.Park(ctx, sess.ID)
+}
+
+// waitSetup polls the member's setup status (the same file the supervisor
+// beacons to ls/TUI). "running" — and, before the setup window has spun up,
+// a missing file — keep it waiting; "0" succeeds; anything else fails with
+// the log tail.
+func waitSetup(ctx context.Context, p Params, id string) error {
+	deadline := time.Now().Add(setupWait)
+	for {
+		out, err := p.Driver.Exec(ctx, id, "cat ~/.pier-setup.status 2>/dev/null || echo none")
+		if err != nil && ctx.Err() != nil {
+			return err
+		}
+		if err == nil {
+			switch status := strings.TrimSpace(out); status {
+			case "0":
+				return nil
+			case "none", "running":
+			default:
+				tail, _ := p.Driver.Exec(ctx, id, "tail -n 15 ~/.pier-setup.log 2>/dev/null")
+				return fmt.Errorf(".pier-setup.sh failed (exit %s) on the pool member:\n%s", status, tail)
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("setup still running after %s — not pooling this member", setupWait)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+// Drain destroys every pool member of the repo, any generation, and returns
+// how many it took down. Claimed members are sessions, not members — they
+// are never touched.
+func Drain(ctx context.Context, drv driver.Driver, sessions []driver.Session, repo string, progress func(string)) (int, error) {
+	if progress == nil {
+		progress = func(string) {}
+	}
+	n := 0
+	for _, m := range Members(sessions, repo) {
+		if m.State == driver.StateDeleting {
+			continue
+		}
+		progress("destroying " + m.Name)
+		if err := drv.Destroy(ctx, m.ID); err != nil {
+			return n, err
+		}
+		n++
+	}
+	return n, nil
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1,0 +1,195 @@
+// Package pool implements repo-scoped warm session pools: pre-provisioned,
+// parked instances whose repo checkout and .pier-setup.sh already ran, so a
+// new session is a resume + freshen instead of a full create. Strictly
+// opt-in (a pool exists only when the user sets a size) and driver-agnostic:
+// everything here goes through the driver interface — members are ordinary
+// instances plus one pool tag, and all pool state derives from provider
+// tags/labels like everything else in pier. No daemon refills pools; fill
+// runs when the user asks and detached after a claim consumes a member.
+package pool
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/kerem-kaynak/pier/internal/driver"
+	"github.com/kerem-kaynak/pier/internal/driver/payload"
+)
+
+const (
+	// FillLeash is the idle timeout members are created with: the supervisor
+	// self-parks them shortly after setup finishes even when the laptop
+	// running the fill dies first. Claim hands the user's real timeouts back.
+	FillLeash = 2 * time.Minute
+	// FillGrace is how long an unparked member may stay unparked before
+	// reconcile treats it as a corpse: past it, either the fill died before
+	// its member parked or setup is looping — a running instance nobody will
+	// claim burns real money. Exported so doctor and the TUI census can flag
+	// the same corpses reconcile would collect.
+	FillGrace = 2 * time.Hour
+	// setupWait bounds fill's wait for .pier-setup.sh. A setup this slow is
+	// broken, not warm.
+	setupWait = 45 * time.Minute
+)
+
+// Params carries everything fill and claim need, resolved by the cmd layer
+// (config values, the repo's baked image, the driver's manifest/env) so this
+// package stays config-agnostic.
+type Params struct {
+	Driver   driver.Driver
+	RepoRoot string // local checkout; fill and claim run from inside it
+	Gen      string // current generation (Generation(...))
+	Size     int    // desired warm member count
+	MaxAge   time.Duration
+	Image    string // the repo's baked image; "" = stock
+
+	// The user's configured timeouts: claim restores them (fill uses FillLeash).
+	IdleTimeout   time.Duration
+	UnattendedCap time.Duration
+
+	Manifest   []string          // $HOME-relative files, same as the driver gets
+	SessionEnv map[string]string // ~/.config/pier/env content, same as the driver gets
+	Progress   func(string)
+}
+
+func (p *Params) progress() func(string) {
+	if p.Progress == nil {
+		return func(string) {}
+	}
+	return p.Progress
+}
+
+// Generation fingerprints everything that makes a warm member equivalent to
+// a fresh create: a member built under a different driver, image, shape, or
+// setup script is stale and gets recycled rather than claimed. 12 hex chars —
+// lowercase, so it is valid as an EC2 tag value and a GCE label value alike.
+func Generation(driverName, image, instanceType string, diskGiB int, setupScript []byte) string {
+	setup := sha256.Sum256(setupScript)
+	h := sha256.New()
+	fmt.Fprintf(h, "%s|%s|%s|%d|%x", driverName, image, instanceType, diskGiB, setup)
+	return hex.EncodeToString(h.Sum(nil))[:12]
+}
+
+// SetupScript returns the bytes of the setup script a session of this repo
+// would run: the PIER_SETUP_SCRIPT override when set, else the repo's
+// .pier-setup.sh, else nil. Feeds the generation fingerprint, and tells fill
+// whether a setup status is expected at all.
+func SetupScript(repoRoot string) []byte {
+	p := os.Getenv("PIER_SETUP_SCRIPT")
+	if p == "" {
+		p = filepath.Join(repoRoot, ".pier-setup.sh")
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// Members filters a List to the unclaimed pool members of one repo (basename).
+func Members(sessions []driver.Session, repo string) []driver.Session {
+	var out []driver.Session
+	for _, s := range sessions {
+		if s.PoolGen != "" && s.Repo == repo {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Plan is Reconcile's verdict on one repo's pool.
+type Plan struct {
+	Ready    []driver.Session // parked, current gen, young enough — claimable, newest first
+	InFlight int              // unparked but within the fill grace: a fill in progress
+	Fill     int              // members to create
+	Stale    []driver.Session // wrong gen, over age, dead, or grace-blown — destroy
+}
+
+// Reconcile classifies members against the desired state. Pure: callers pass
+// time.Now(). Members mid-delete are ignored (they are going away on their
+// own); when the pool holds more ready members than size wants, the oldest
+// spill into Stale.
+func Reconcile(members []driver.Session, size int, gen string, maxAge time.Duration, now time.Time) Plan {
+	var p Plan
+	for _, m := range members {
+		age := now.Sub(m.Created)
+		switch {
+		case m.State == driver.StateDeleting:
+		case m.PoolGen != gen, age >= maxAge, m.State == driver.StateDead:
+			p.Stale = append(p.Stale, m)
+		case m.State == driver.StateParked:
+			p.Ready = append(p.Ready, m)
+		case age < FillGrace:
+			p.InFlight++
+		default:
+			p.Stale = append(p.Stale, m)
+		}
+	}
+	slices.SortFunc(p.Ready, func(a, b driver.Session) int {
+		return b.Created.Compare(a.Created)
+	})
+	if len(p.Ready) > size {
+		// In-flight members don't count against ready ones here: a warm,
+		// claimable member never drains in favor of an unfinished fill (which
+		// may yet fail). Once that fill parks, the next reconcile trims the
+		// brief overage — parked members cost pennies in the meantime.
+		p.Stale = append(p.Stale, p.Ready[size:]...)
+		p.Ready = p.Ready[:size]
+	}
+	if n := size - len(p.Ready) - p.InFlight; n > 0 {
+		p.Fill = n
+	}
+	return p
+}
+
+// placeholderName names an unclaimed member: pool-<repo>-<rand4>. Passes the
+// same name validation as user branches (Sanitize folds to its charset). The
+// repo part is capped so the whole name stays inside GCE's 63-char instance
+// name limit with room for the drivers' prefix — a long repo name must never
+// squeeze out the random suffix that keeps members distinct.
+func placeholderName(repoRoot string) (string, error) {
+	b := make([]byte, 2)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	base := payload.Sanitize(filepath.Base(repoRoot))
+	if len(base) > 32 {
+		base = strings.TrimRight(base[:32], "-")
+	}
+	return "pool-" + base + "-" + hex.EncodeToString(b), nil
+}
+
+// newNonce mints a claim token: lowercase hex, so it is valid as an EC2 tag
+// value and a GCE label value alike.
+func newNonce() (string, error) {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// pickOrder returns candidate indices starting at a nonce-derived offset,
+// then wrapping: two concurrent claimers usually go for different members,
+// so the nonce read-back in Claim rarely even has a race to settle.
+func pickOrder(n int, nonce string) []int {
+	if n <= 0 {
+		return nil
+	}
+	h := fnv.New32a()
+	h.Write([]byte(nonce))
+	start := int(h.Sum32() % uint32(n))
+	out := make([]int, 0, n)
+	for i := range n {
+		out = append(out, (start+i)%n)
+	}
+	return out
+}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1,0 +1,142 @@
+package pool
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerem-kaynak/pier/internal/driver"
+	"github.com/kerem-kaynak/pier/internal/driver/payload"
+)
+
+// The generation is the staleness contract: any input that changes what a
+// fresh create would produce must change it, and nothing else may.
+func TestGeneration(t *testing.T) {
+	base := Generation("aws-ec2", "ami-1", "t4g.medium", 40, []byte("npm ci"))
+	if again := Generation("aws-ec2", "ami-1", "t4g.medium", 40, []byte("npm ci")); again != base {
+		t.Errorf("generation is not stable: %s vs %s", base, again)
+	}
+	if len(base) != 12 || base != strings.ToLower(base) {
+		t.Errorf("generation %q must be 12 lowercase hex chars (GCE label + EC2 tag safe)", base)
+	}
+	for name, gen := range map[string]string{
+		"driver":  Generation("gcp-gce", "ami-1", "t4g.medium", 40, []byte("npm ci")),
+		"image":   Generation("aws-ec2", "ami-2", "t4g.medium", 40, []byte("npm ci")),
+		"type":    Generation("aws-ec2", "ami-1", "t4g.large", 40, []byte("npm ci")),
+		"disk":    Generation("aws-ec2", "ami-1", "t4g.medium", 80, []byte("npm ci")),
+		"setup":   Generation("aws-ec2", "ami-1", "t4g.medium", 40, []byte("npm ci && make")),
+		"nosetup": Generation("aws-ec2", "ami-1", "t4g.medium", 40, nil),
+	} {
+		if gen == base {
+			t.Errorf("changing %s did not change the generation", name)
+		}
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	now := time.Now()
+	gen := "aaaaaaaaaaaa"
+	maxAge := 14 * 24 * time.Hour
+	member := func(id string, st driver.State, g string, age time.Duration) driver.Session {
+		return driver.Session{ID: id, Name: id, State: st, PoolGen: g, Created: now.Add(-age)}
+	}
+
+	p := Reconcile([]driver.Session{
+		member("ready-new", driver.StateParked, gen, time.Hour),
+		member("ready-old", driver.StateParked, gen, 48*time.Hour),
+		member("wrong-gen", driver.StateParked, "bbbbbbbbbbbb", time.Hour),
+		member("over-age", driver.StateParked, gen, maxAge+time.Hour),
+		member("filling", driver.StateCreating, gen, 5*time.Minute),
+		member("grace-blown", driver.StateRunning, gen, 3*time.Hour),
+		member("dead", driver.StateDead, gen, time.Hour),
+		member("going-away", driver.StateDeleting, gen, time.Hour),
+	}, 5, gen, maxAge, now)
+
+	ready := ids(p.Ready)
+	if want := []string{"ready-new", "ready-old"}; !slices.Equal(ready, want) {
+		t.Errorf("Ready = %v, want %v (newest first)", ready, want)
+	}
+	if p.InFlight != 1 {
+		t.Errorf("InFlight = %d, want 1", p.InFlight)
+	}
+	stale := ids(p.Stale)
+	slices.Sort(stale)
+	if want := []string{"dead", "grace-blown", "over-age", "wrong-gen"}; !slices.Equal(stale, want) {
+		t.Errorf("Stale = %v, want %v", stale, want)
+	}
+	// 5 wanted - 2 ready - 1 in flight
+	if p.Fill != 2 {
+		t.Errorf("Fill = %d, want 2", p.Fill)
+	}
+}
+
+// Shrinking the pool must drain the oldest ready members, never the in-flight
+// ones (they belong to a live fill whose failure path destroys them itself).
+func TestReconcileShrink(t *testing.T) {
+	now := time.Now()
+	gen := "aaaaaaaaaaaa"
+	members := []driver.Session{
+		{ID: "old", Name: "old", State: driver.StateParked, PoolGen: gen, Created: now.Add(-3 * time.Hour)},
+		{ID: "new", Name: "new", State: driver.StateParked, PoolGen: gen, Created: now.Add(-time.Hour)},
+		{ID: "filling", Name: "filling", State: driver.StateCreating, PoolGen: gen, Created: now.Add(-time.Minute)},
+	}
+	p := Reconcile(members, 1, gen, 14*24*time.Hour, now)
+	if want := []string{"new", "old"}; !slices.Equal(ids(p.Stale), []string{"old"}) || !slices.Equal(ids(p.Ready), want[:1]) {
+		t.Errorf("shrink to 1: Ready = %v, Stale = %v; want Ready [new], Stale [old]", ids(p.Ready), ids(p.Stale))
+	}
+	if p.Fill != 0 {
+		t.Errorf("Fill = %d, want 0 (ready + in-flight covers the size)", p.Fill)
+	}
+	if p := Reconcile(members, 0, gen, 14*24*time.Hour, now); len(p.Ready) != 0 || len(p.Stale) != 2 {
+		t.Errorf("shrink to 0: Ready = %v, Stale = %v; want all ready drained", ids(p.Ready), ids(p.Stale))
+	}
+}
+
+func ids(members []driver.Session) []string {
+	var out []string
+	for _, m := range members {
+		out = append(out, m.ID)
+	}
+	return out
+}
+
+// pickOrder spreads concurrent claimers across members but must still visit
+// every candidate, or a lost race would strand claimable members.
+func TestPickOrder(t *testing.T) {
+	order := pickOrder(5, "abc123")
+	if len(order) != 5 {
+		t.Fatalf("pickOrder(5) visits %d members, want 5", len(order))
+	}
+	sorted := slices.Clone(order)
+	slices.Sort(sorted)
+	if !slices.Equal(sorted, []int{0, 1, 2, 3, 4}) {
+		t.Errorf("pickOrder(5) = %v, want a permutation-by-rotation of 0..4", order)
+	}
+	if !slices.Equal(order, pickOrder(5, "abc123")) {
+		t.Error("pickOrder is not deterministic for one nonce")
+	}
+	if pickOrder(0, "abc123") != nil {
+		t.Error("pickOrder(0) must be nil")
+	}
+}
+
+// The placeholder rides everywhere a session name does (tags, hostnames,
+// bootstrap splices), so it must pass the same validation.
+func TestPlaceholderName(t *testing.T) {
+	name, err := placeholderName("/Users/x/My_Repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(name, "pool-my-repo-") {
+		t.Errorf("placeholderName = %q, want pool-my-repo-<rand> (Sanitize folds the basename)", name)
+	}
+	spec := driver.CreateSpec{Name: name, Branch: name, Repo: "/Users/x/My_Repo"}
+	if err := payload.ValidateNames(spec); err != nil {
+		t.Errorf("placeholder %q fails name validation: %v", name, err)
+	}
+	other, _ := placeholderName("/Users/x/My_Repo")
+	if name == other {
+		t.Errorf("two placeholders collided: %q", name)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -143,6 +143,12 @@ func Run(ctx context.Context, drv driver.Driver, opt Options) error {
 		default:
 			live := map[string]driver.Session{}
 			for _, s := range sessions {
+				if s.PoolGen != "" {
+					// Unclaimed pool members run while they fill — plumbing,
+					// not work. No hostname, and no proxy connection holding
+					// one open past its self-park.
+					continue
+				}
 				switch s.State {
 				case driver.StateRunning, driver.StateWorking, driver.StateIdle:
 					live[s.ID] = s

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kerem-kaynak/pier/internal/config"
 	"github.com/kerem-kaynak/pier/internal/driver"
+	"github.com/kerem-kaynak/pier/internal/pool"
 	"github.com/kerem-kaynak/pier/internal/ui"
 )
 
@@ -54,6 +55,68 @@ type Options struct {
 	// ssh transport failure (fresh or just-resumed VMs); nil disables the retry.
 	RetryAttach   func(err error, elapsed time.Duration) bool
 	WaitReachable func(s driver.Session) error
+	// Pools power the w key's warm-pool page and the header's warm count.
+	// PoolSizes re-reads the configured repo→size map (config may change
+	// between opens). CurrentRepo/CurrentGen describe the repo pier launched
+	// from ("" outside a repo): only its row is size-editable — a fill needs
+	// the local checkout — and only its members can be staleness-checked (the
+	// generation hashes the local setup script). nil PoolSizes hides the page.
+	PoolSizes   func() map[string]int
+	CurrentRepo string
+	CurrentGen  string
+	// PoolMaxAge is the configured member recycle age (0 = don't check);
+	// members past it show stale. PoolNote explains a pool page that is
+	// read-only for a reason worth a sentence (a broken [pool] config, say)
+	// instead of the generic run-from-a-repo hint.
+	PoolMaxAge time.Duration
+	PoolNote   string
+	// PoolSet saves the current repo's size and reconciles: 0 drains inline,
+	// >0 starts a detached fill and returns its log path.
+	PoolSet func(size int) (logPath string, err error)
+	// PoolFill starts a detached fill for the current repo.
+	PoolFill func() (logPath string, err error)
+	// PoolDrain destroys a repo's warm members — any repo; draining needs no
+	// local checkout — and returns how many went down.
+	PoolDrain func(repo string) (int, error)
+}
+
+// PoolStats is one repo's warm-member census, shared by the TUI page and
+// `pier pool`.
+type PoolStats struct {
+	Ready, Filling, Stale int
+	Ages                  []string // ready members' ages, newest first as listed
+}
+
+// FoldPool folds one repo's unclaimed members out of a session list, judging
+// them the way reconcile would: dead, wrong-generation, over the recycle age,
+// or unparked past the fill grace all count stale — a member whose fill died
+// hours ago must not read "filling" forever. curGen gates the generation
+// check: only the repo the process runs from can compute its current
+// generation, so other repos' members never show gen-stale (they recycle on
+// their own machines' claims). maxAge 0 skips the age check.
+func FoldPool(sessions []driver.Session, repo, curRepo, curGen string, maxAge time.Duration, now time.Time) PoolStats {
+	var st PoolStats
+	for _, s := range sessions {
+		if s.PoolGen == "" || s.Repo != repo {
+			continue
+		}
+		lived := now.Sub(s.Created)
+		switch {
+		case s.State == driver.StateDeleting:
+		case s.State == driver.StateDead,
+			repo == curRepo && s.PoolGen != curGen,
+			maxAge > 0 && lived >= maxAge:
+			st.Stale++
+		case s.State == driver.StateParked:
+			st.Ready++
+			st.Ages = append(st.Ages, age(s.Created))
+		case lived >= pool.FillGrace:
+			st.Stale++
+		default:
+			st.Filling++
+		}
+	}
+	return st
 }
 
 func Run(opts Options) error {
@@ -70,11 +133,13 @@ const (
 	modeSettings
 	modeResize
 	modeLogs
+	modePool
 )
 
 type model struct {
 	opts      Options
 	sessions  []driver.Session
+	members   []driver.Session // unclaimed warm pool members, split from sessions
 	quota     string
 	cursor    int
 	mode      mode
@@ -102,6 +167,12 @@ type model struct {
 	// resize picker state; machines reload each time m opens the picker
 	machines []driver.Machine
 	machIdx  int
+	// pool page state (modePool); sizes reload each time w opens the page
+	poolRepos   []string // rows: configured repos ∪ repos with members ∪ current repo
+	poolSizes   map[string]int
+	poolIdx     int
+	poolPend    int  // pending size for the current repo's row; -1 = none
+	poolConfirm bool // drain y/n pending
 	// log viewer state (modeLogs); content refetches on a slow cadence so a
 	// still-running setup streams in place
 	logSess    driver.Session
@@ -124,6 +195,33 @@ func anyCreating(sessions []driver.Session) bool {
 	return false
 }
 
+// anyFilling reports whether an unclaimed member is mid-fill (not yet parked);
+// the open pool page keeps refreshing while one is.
+func anyFilling(members []driver.Session) bool {
+	for _, s := range members {
+		switch s.State {
+		case driver.StateParked, driver.StateDead, driver.StateDeleting:
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+// splitMembers separates unclaimed pool members from real sessions: members
+// never sit in the session table (they're plumbing, not work) — they show on
+// the pool page and in the header's warm count.
+func splitMembers(all []driver.Session) (sessions, members []driver.Session) {
+	for _, s := range all {
+		if s.PoolGen != "" {
+			members = append(members, s)
+		} else {
+			sessions = append(sessions, s)
+		}
+	}
+	return sessions, members
+}
+
 type sessionsMsg struct {
 	sessions []driver.Session
 	err      error
@@ -142,6 +240,12 @@ type spawnedMsg struct {
 	branch string
 	log    string
 	err    error
+}
+
+// poolActMsg reports an async pool action (size apply, fill, drain).
+type poolActMsg struct {
+	note string
+	err  error
 }
 
 // resumedMsg reports a parked VM's blocking resume finished (or failed).
@@ -193,13 +297,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status, m.statusBad = msg.err.Error(), true
 			return m, nil
 		}
-		m.sessions = msg.sessions
+		m.sessions, m.members = splitMembers(msg.sessions)
 		if m.cursor >= len(m.sessions) {
 			m.cursor = max(0, len(m.sessions)-1)
 		}
+		if m.mode == modePool {
+			m.reindexPools()
+		}
 		// While anything is still creating, keep refreshing on our own so a
-		// background create walks to "running" without the user pressing r.
-		if !m.polling && anyCreating(m.sessions) {
+		// background create walks to "running" without the user pressing r —
+		// likewise while the open pool page has a member mid-fill.
+		if !m.polling && (anyCreating(m.sessions) || m.mode == modePool && anyFilling(m.members)) {
 			m.polling = true
 			return m, pollCmd()
 		}
@@ -211,7 +319,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// watch keeps the chain alive right after a spawn, before the new
 		// instance is visible in the provider's list.
-		if m.watch > 0 || anyCreating(m.sessions) {
+		if m.watch > 0 || anyCreating(m.sessions) || m.mode == modePool && anyFilling(m.members) {
 			m.polling = true
 			return m, tea.Batch(m.fetch, pollCmd()) // silent refresh: no spinner flicker
 		}
@@ -234,6 +342,28 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case quotaMsg:
 		m.quota = string(msg)
 		return m, nil
+	case poolActMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.status, m.statusBad = msg.err.Error(), true
+			return m, nil
+		}
+		m.status, m.statusBad = msg.note, false
+		if m.opts.PoolSizes != nil {
+			m.poolSizes = m.opts.PoolSizes() // a size apply just changed config
+		}
+		m.reindexPools()
+		m.loading = true
+		// A detached fill takes a beat to launch its instance; without the
+		// watch window the poll chain would die on the first refresh that
+		// still shows nothing filling — same grace a spawned create gets.
+		m.watch = max(m.watch, 24) // ~2min
+		cmds := []tea.Cmd{m.fetch, tickCmd()}
+		if !m.polling { // a fill may now be in flight — watch it land
+			m.polling = true
+			cmds = append(cmds, pollCmd())
+		}
+		return m, tea.Batch(cmds...)
 	case resumedMsg:
 		m.loading = false
 		if msg.err != nil {
@@ -324,6 +454,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateResize(msg)
 		case modeLogs:
 			return m.updateLogs(msg)
+		case modePool:
+			return m.updatePool(msg)
 		}
 		return m.updateList(msg)
 	}
@@ -440,6 +572,11 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.mode = modeResize
 		}
+	case "w":
+		if m.opts.PoolSizes == nil {
+			return m, nil
+		}
+		return m.openPools()
 	case "s":
 		cfg, err := config.Load()
 		if err != nil {
@@ -695,6 +832,303 @@ func (m model) updateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// openPools enters the w page: sizes reload fresh (config may have changed
+// under us), rows rebuild from config ∪ live members, and the cursor lands on
+// the repo pier launched from — the only size-editable row.
+func (m model) openPools() (tea.Model, tea.Cmd) {
+	m.poolSizes = m.opts.PoolSizes()
+	m.poolRepos = poolRepoRows(m.poolSizes, m.members, m.opts.CurrentRepo)
+	m.poolIdx, m.poolPend, m.poolConfirm = 0, -1, false
+	for i, r := range m.poolRepos {
+		if r == m.opts.CurrentRepo {
+			m.poolIdx = i
+		}
+	}
+	m.mode = modePool
+	if !m.polling && anyFilling(m.members) {
+		m.polling = true
+		return m, pollCmd()
+	}
+	return m, nil
+}
+
+// reindexPools rebuilds the page's rows after a refresh or action, keeping the
+// cursor on the same repo when it survives. A vanished row (drained from
+// another terminal mid-refresh) takes its staged edit and confirm prompt with
+// it — they referred to a repo that no longer has a row.
+func (m *model) reindexPools() {
+	cur := ""
+	if m.poolIdx < len(m.poolRepos) {
+		cur = m.poolRepos[m.poolIdx]
+	}
+	m.poolRepos = poolRepoRows(m.poolSizes, m.members, m.opts.CurrentRepo)
+	m.poolIdx = 0
+	found := false
+	for i, r := range m.poolRepos {
+		if r == cur {
+			m.poolIdx, found = i, true
+		}
+	}
+	if !found {
+		m.poolPend, m.poolConfirm = -1, false
+	}
+}
+
+// poolRepoRows is every repo worth a row: configured pools, repos that still
+// have members on the provider (orphans included — they cost money), and the
+// repo pier launched from, so + works before any pool exists.
+func poolRepoRows(sizes map[string]int, members []driver.Session, curRepo string) []string {
+	set := map[string]bool{}
+	for r := range sizes {
+		set[r] = true
+	}
+	for _, s := range members {
+		set[s.Repo] = true
+	}
+	if curRepo != "" {
+		set[curRepo] = true
+	}
+	rows := make([]string, 0, len(set))
+	for r := range set {
+		rows = append(rows, r)
+	}
+	sort.Strings(rows)
+	return rows
+}
+
+func (m model) updatePool(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.poolConfirm {
+		m.poolConfirm = false
+		if msg.String() == "y" {
+			repo := m.poolRepos[m.poolIdx]
+			drain := m.opts.PoolDrain
+			m.loading = true
+			return m, tea.Batch(func() tea.Msg {
+				n, err := drain(repo)
+				if err != nil {
+					return poolActMsg{err: err}
+				}
+				return poolActMsg{note: fmt.Sprintf("drained %d member(s) from %s", n, repo)}
+			}, tickCmd())
+		}
+		return m, nil
+	}
+	m.status = ""
+	row := ""
+	if m.poolIdx < len(m.poolRepos) {
+		row = m.poolRepos[m.poolIdx]
+	}
+	switch msg.String() {
+	case "q", "esc", "ctrl+c":
+		if m.poolPend >= 0 { // first esc cancels the unapplied size
+			m.poolPend = -1
+			return m, nil
+		}
+		m.mode = modeList
+	case "up", "k":
+		if m.poolIdx > 0 {
+			m.poolIdx--
+			m.poolPend = -1
+		}
+	case "down", "j":
+		if m.poolIdx < len(m.poolRepos)-1 {
+			m.poolIdx++
+			m.poolPend = -1
+		}
+	case "+", "=", "right":
+		return m.bumpPool(row, 1)
+	case "-", "_", "left":
+		return m.bumpPool(row, -1)
+	case "enter":
+		if row == "" || row != m.opts.CurrentRepo || m.opts.PoolSet == nil ||
+			m.poolPend < 0 || m.poolPend == m.poolSizes[row] {
+			m.poolPend = -1
+			return m, nil
+		}
+		size, set := m.poolPend, m.opts.PoolSet
+		m.poolPend = -1
+		m.loading = true
+		return m, tea.Batch(func() tea.Msg {
+			logPath, err := set(size)
+			switch {
+			case err != nil:
+				return poolActMsg{err: err}
+			case size == 0:
+				return poolActMsg{note: "pool off — members drained"}
+			default:
+				return poolActMsg{note: fmt.Sprintf("pool size %d — filling in the background (log: %s)", size, ui.Tilde(logPath))}
+			}
+		}, tickCmd())
+	case "f":
+		if row == "" || m.opts.PoolFill == nil {
+			return m, nil
+		}
+		if row != m.opts.CurrentRepo {
+			m.status, m.statusBad = "run pier from inside "+row+" to fill its pool — the fill needs the local checkout", false
+			return m, nil
+		}
+		if m.poolSizes[row] == 0 {
+			m.status, m.statusBad = "pool size is 0 — press + then enter to warm one", false
+			return m, nil
+		}
+		fill := m.opts.PoolFill
+		m.loading = true
+		return m, tea.Batch(func() tea.Msg {
+			logPath, err := fill()
+			if err != nil {
+				return poolActMsg{err: err}
+			}
+			return poolActMsg{note: "filling in the background (log: " + ui.Tilde(logPath) + ")"}
+		}, tickCmd())
+	case "d":
+		if row == "" || m.opts.PoolDrain == nil {
+			return m, nil
+		}
+		st := FoldPool(m.members, row, m.opts.CurrentRepo, m.opts.CurrentGen, m.opts.PoolMaxAge, time.Now())
+		if st.Ready+st.Filling+st.Stale == 0 {
+			m.status, m.statusBad = "no warm members to drain for "+row, false
+			return m, nil
+		}
+		m.poolConfirm = true
+	case "r":
+		m.loading = true
+		return m, tea.Batch(m.fetch, tickCmd())
+	}
+	return m, nil
+}
+
+// bumpPool nudges the pending size on the current repo's row; other repos
+// can't be resized from here — a fill needs their local checkout.
+func (m model) bumpPool(row string, delta int) (tea.Model, tea.Cmd) {
+	if row == "" {
+		return m, nil
+	}
+	if row != m.opts.CurrentRepo {
+		m.status, m.statusBad = "run pier from inside "+row+" to resize its pool", false
+		return m, nil
+	}
+	if m.poolPend < 0 {
+		m.poolPend = m.poolSizes[row]
+	}
+	m.poolPend = min(8, max(0, m.poolPend+delta))
+	return m, nil
+}
+
+// poolView is the w page: one row per repo with its configured size, live
+// member census, and the monthly cost of what's parked. Only the current
+// repo's row is size-editable (the generation hashes the local setup script);
+// any repo's members can be drained.
+func (m model) poolView() string {
+	var b strings.Builder
+	head := " " + ui.Title.Render("⚓ pier pools") +
+		ui.Dim.Render("  parked sessions ready to claim — pier <branch> grabs one")
+	if m.loading {
+		head += " " + ui.Accent.Render(spinner[m.frame%len(spinner)])
+	}
+	b.WriteString("\n" + head + "\n\n")
+
+	if len(m.poolRepos) == 0 {
+		b.WriteString(ui.Dim.Render("   no pools — run pier from inside a repo and press + to warm one") + "\n")
+	} else {
+		repoW := 4
+		for _, r := range m.poolRepos {
+			repoW = max(repoW, len(r))
+		}
+		b.WriteString(ui.Dim.Render(fmt.Sprintf("   %-*s  %-6s  %s", repoW, "REPO", "SIZE", "WARM")) + "\n")
+		ready, filling := 0, 0
+		now := time.Now()
+		rows := make([]string, 0, len(m.poolRepos))
+		for i, repo := range m.poolRepos {
+			st := FoldPool(m.members, repo, m.opts.CurrentRepo, m.opts.CurrentGen, m.opts.PoolMaxAge, now)
+			ready += st.Ready
+			filling += st.Filling
+			size := fmt.Sprintf("%-6d", m.poolSizes[repo])
+			if i == m.poolIdx && m.poolPend >= 0 && m.poolPend != m.poolSizes[repo] {
+				size = fmt.Sprintf("%-6s", fmt.Sprintf("%d→%d", m.poolSizes[repo], m.poolPend))
+			}
+			marker, name := "   ", fmt.Sprintf("%-*s", repoW, repo)
+			if i == m.poolIdx {
+				marker = " " + ui.Accent.Render("▸") + " "
+				name = ui.Bold.Render(name)
+			}
+			cell := poolCell(repo, m.poolSizes[repo], st, m.opts.CurrentRepo)
+			if repo == m.opts.CurrentRepo {
+				cell += ui.Dim.Render("  · this repo")
+			}
+			rows = append(rows, fmt.Sprintf("%s%s  %s  %s", marker, name, size, cell))
+		}
+		// Chrome around the row window: title block (3), table header (1),
+		// cost (2) and the footer below (up to 4 lines).
+		for _, row := range m.windowBody(rows, m.poolIdx, 10) {
+			b.WriteString(row + "\n")
+		}
+		// Parked is the only state that costs disk money alone; a filling
+		// member is a running instance billing at full rate until it parks.
+		if ready > 0 || filling > 0 {
+			cost := fmt.Sprintf("cost: %d parked × ~$3-4/mo disk", ready)
+			if filling > 0 {
+				cost += fmt.Sprintf(" · %d filling at full instance rate until parked", filling)
+			}
+			b.WriteString("\n " + ui.Dim.Render(cost) + "\n")
+		}
+	}
+	b.WriteString("\n")
+
+	if m.poolConfirm {
+		b.WriteString(" " + ui.Warn.Render(fmt.Sprintf("drain %s — destroy its warm members? (y/n)", m.poolRepos[m.poolIdx])) + "\n")
+		return b.String()
+	}
+	if m.status != "" {
+		if m.statusBad {
+			b.WriteString(" " + ui.Bad.Render("! "+m.status) + "\n")
+		} else {
+			b.WriteString(" " + ui.Accent.Render("▸ "+m.status) + "\n")
+		}
+	}
+	if m.opts.CurrentRepo == "" {
+		hint := "read-only: run pier from inside a repo to size its pool"
+		if m.opts.PoolNote != "" {
+			hint = "read-only: " + m.opts.PoolNote
+		}
+		b.WriteString(" " + ui.Dim.Render(hint) + "\n")
+	}
+	b.WriteString(" " + ui.Keys("+/-", "size", "enter", "apply", "f", "fill", "d", "drain", "r", "refresh", "esc", "back") + "\n")
+	return b.String()
+}
+
+// poolCell describes one repo's members: ready with ages, filling, stale —
+// or why an empty row exists at all.
+func poolCell(repo string, size int, st PoolStats, curRepo string) string {
+	var parts []string
+	if st.Ready > 0 {
+		cell := fmt.Sprintf("● %d ready", st.Ready)
+		if len(st.Ages) > 0 {
+			cell += " (" + strings.Join(st.Ages, ", ") + ")"
+		}
+		parts = append(parts, ui.OK.Render(cell))
+	}
+	if st.Filling > 0 {
+		parts = append(parts, ui.Warn.Render(fmt.Sprintf("◐ %d filling", st.Filling)))
+	}
+	if st.Stale > 0 {
+		parts = append(parts, ui.Bad.Render(fmt.Sprintf("✗ %d stale", st.Stale)))
+	}
+	if len(parts) == 0 {
+		switch {
+		case size == 0:
+			return ui.Dim.Render("(off)")
+		case repo == curRepo:
+			return ui.Dim.Render("empty — f fills")
+		default:
+			return ui.Dim.Render("empty")
+		}
+	}
+	if size == 0 {
+		parts = append(parts, ui.Dim.Render("orphaned — pool is off; d drains"))
+	}
+	return strings.Join(parts, "  ")
+}
+
 var spinner = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
 func (m model) View() string {
@@ -704,12 +1138,18 @@ func (m model) View() string {
 	if m.mode == modeLogs {
 		return m.logsView()
 	}
+	if m.mode == modePool {
+		return m.poolView()
+	}
 	var b strings.Builder
 
 	head := " " + ui.Title.Render("⚓ pier")
 	var meta []string
 	if m.loaded {
 		meta = append(meta, fmt.Sprintf("%d session(s)", len(m.sessions)))
+		if n := len(m.members); n > 0 {
+			meta = append(meta, fmt.Sprintf("%d warm", n))
+		}
 	}
 	if m.quota != "" {
 		meta = append(meta, m.quota)
@@ -763,7 +1203,12 @@ func (m model) View() string {
 				b.WriteString(" " + ui.Accent.Render("▸ "+m.status) + "\n")
 			}
 		}
-		b.WriteString(" " + ui.Keys("enter", "attach", "n", "new", "d", "delete", "p", "pin", "m", "resize", "l", "logs", "s", "settings", "r", "refresh", "q", "quit") + "\n")
+		keys := []string{"enter", "attach", "n", "new", "d", "delete", "p", "pin", "m", "resize", "l", "logs"}
+		if m.opts.PoolSizes != nil {
+			keys = append(keys, "w", "pools")
+		}
+		keys = append(keys, "s", "settings", "r", "refresh", "q", "quit")
+		b.WriteString(" " + ui.Keys(keys...) + "\n")
 	}
 	return b.String()
 }
@@ -920,11 +1365,22 @@ func (m model) readonlyLines() []string {
 		}
 		return "   " + ui.Dim.Render(label+"  ") + val + ui.Dim.Render("  ("+mgr+")")
 	}
+	pools := ui.Dim.Render("(none)")
+	if len(c.Pool.Sizes) > 0 {
+		pairs := make([]string, 0, len(c.Pool.Sizes))
+		for repo, n := range c.Pool.Sizes {
+			pairs = append(pairs, fmt.Sprintf("%s × %d", repo, n))
+		}
+		sort.Strings(pairs)
+		pools = strings.Join(pairs, " · ")
+	}
+
 	return []string{
 		" " + ui.Dim.Render("managed elsewhere"),
 		row("secrets → sessions", secrets, "pier setup"),
 		row("claude token", token, "claude setup-token"),
 		row("baked images", baked, "pier bake"),
+		row("warm pools", pools, "w / pier pool"),
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -474,6 +474,216 @@ func TestTableWindowFollowsCursor(t *testing.T) {
 	}
 }
 
+// FoldPool classifies members the way reconcile would; the generation check
+// applies only to the repo whose local checkout produced curGen — other
+// repos' gens are unknowable here.
+func TestFoldPool(t *testing.T) {
+	now := time.Now()
+	ss := []driver.Session{
+		{Repo: "shop", PoolGen: "aaa", State: driver.StateParked, Created: now.Add(-time.Hour)},
+		{Repo: "shop", PoolGen: "bbb", State: driver.StateParked, Created: now}, // wrong gen
+		{Repo: "shop", PoolGen: "aaa", State: driver.StateCreating, Created: now},
+		{Repo: "shop", PoolGen: "aaa", State: driver.StateDead, Created: now},
+		{Repo: "shop", PoolGen: "aaa", State: driver.StateDeleting, Created: now},
+		{Repo: "shop", State: driver.StateRunning, Created: now}, // a real session
+		{Repo: "tools", PoolGen: "zzz", State: driver.StateParked, Created: now},
+	}
+	if st := FoldPool(ss, "shop", "shop", "aaa", 0, now); st.Ready != 1 || st.Filling != 1 || st.Stale != 2 {
+		t.Errorf("shop = %+v, want 1 ready, 1 filling, 2 stale", st)
+	}
+	if st := FoldPool(ss, "tools", "shop", "aaa", 0, now); st.Ready != 1 || st.Stale != 0 {
+		t.Errorf("tools = %+v, want its member ready (gen unknowable from here)", st)
+	}
+
+	// Age judgments: a parked member past max_age is stale even for repos
+	// whose gen is unknowable, and an unparked member past the fill grace is
+	// a corpse, not "filling" — its fill died hours ago.
+	old := []driver.Session{
+		{Repo: "tools", PoolGen: "zzz", State: driver.StateParked, Created: now.Add(-30 * 24 * time.Hour)},
+		{Repo: "tools", PoolGen: "zzz", State: driver.StateCreating, Created: now.Add(-3 * time.Hour)},
+	}
+	if st := FoldPool(old, "tools", "", "", 14*24*time.Hour, now); st.Ready != 0 || st.Filling != 0 || st.Stale != 2 {
+		t.Errorf("old members = %+v, want both stale (over-age + grace-blown)", st)
+	}
+	if st := FoldPool(old[:1], "tools", "", "", 0, now); st.Ready != 1 {
+		t.Errorf("maxAge 0 = %+v, want the age check skipped", st)
+	}
+}
+
+// The w page is the primary pool surface: members split out of the session
+// list (never as table rows), the header counts them, and the page shows
+// per-repo warmth with what it costs.
+func TestPoolPage(t *testing.T) {
+	if got, _ := (model{loaded: true}).updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("w")}); got.(model).mode != modeList {
+		t.Error("w without pool hooks wired must be a no-op")
+	}
+
+	now := time.Now()
+	m := model{loaded: true, opts: Options{
+		PoolSizes:   func() map[string]int { return map[string]int{"shop": 2} },
+		CurrentRepo: "shop",
+		CurrentGen:  "aaaaaaaaaaaa",
+	}}
+	got, _ := m.Update(sessionsMsg{sessions: []driver.Session{
+		{Name: "fix-auth", Repo: "shop", State: driver.StateRunning, Created: now},
+		{Name: "pool-shop-a1b2", Repo: "shop", State: driver.StateParked, PoolGen: "aaaaaaaaaaaa", Created: now.Add(-time.Hour)},
+		{Name: "pool-shop-c3d4", Repo: "shop", State: driver.StateCreating, PoolGen: "aaaaaaaaaaaa", Created: now},
+		{Name: "pool-tools-e5f6", Repo: "tools", State: driver.StateParked, PoolGen: "bbbbbbbbbbbb", Created: now},
+	}})
+	m = got.(model)
+
+	v := m.View()
+	if strings.Contains(v, "pool-shop-a1b2") {
+		t.Errorf("pool members must never render as session rows:\n%s", v)
+	}
+	if !strings.Contains(v, "1 session(s)") || !strings.Contains(v, "3 warm") {
+		t.Errorf("header must count sessions and warm members separately:\n%s", v)
+	}
+
+	got, _ = m.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("w")})
+	m = got.(model)
+	if m.mode != modePool {
+		t.Fatalf("w must open the pool page, got mode=%v", m.mode)
+	}
+	if m.poolRepos[m.poolIdx] != "shop" {
+		t.Errorf("cursor must land on the current repo, got %q", m.poolRepos[m.poolIdx])
+	}
+	v = m.View()
+	for _, want := range []string{"pier pools", "shop", "1 ready", "1 filling", "tools", "$3-4/mo", "this repo"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("pool page missing %q:\n%s", want, v)
+		}
+	}
+	// tools has a member but no configured pool — that's money leaking.
+	if !strings.Contains(v, "orphaned") {
+		t.Errorf("members without a configured pool must show as orphaned:\n%s", v)
+	}
+}
+
+// Sizing works only on the current repo's row, stages with +/- (rendered as
+// from→to), applies on enter through PoolSet, and esc cancels the staging
+// before it leaves the page.
+func TestPoolSizeEditing(t *testing.T) {
+	applied := -1
+	sizes := map[string]int{"shop": 1}
+	m := model{loaded: true, mode: modePool,
+		poolSizes: sizes, poolRepos: []string{"other", "shop"}, poolIdx: 1, poolPend: -1,
+		members: []driver.Session{{Name: "pool-other-x", Repo: "other", State: driver.StateParked, PoolGen: "g", Created: time.Now()}},
+		opts: Options{
+			CurrentRepo: "shop",
+			PoolSizes:   func() map[string]int { return sizes },
+			Fetch:       func() ([]driver.Session, error) { return nil, nil },
+			PoolSet:     func(size int) (string, error) { applied = size; return "/tmp/pool-shop.log", nil },
+		}}
+
+	for range 2 {
+		got, _ := m.updatePool(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("+")})
+		m = got.(model)
+	}
+	if m.poolPend != 3 || applied != -1 {
+		t.Fatalf("+ must stage, not apply: pend=%d applied=%d", m.poolPend, applied)
+	}
+	if v := m.View(); !strings.Contains(v, "1→3") {
+		t.Errorf("a staged size must render as from→to:\n%s", v)
+	}
+
+	got, _ := m.updatePool(tea.KeyMsg{Type: tea.KeyEsc})
+	m = got.(model)
+	if m.poolPend != -1 || m.mode != modePool {
+		t.Fatalf("first esc must only cancel the staged size, got pend=%d mode=%v", m.poolPend, m.mode)
+	}
+
+	got, _ = m.updatePool(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("+")})
+	m = got.(model)
+	got, cmd := m.updatePool(tea.KeyMsg{Type: tea.KeyEnter})
+	m = got.(model)
+	if cmd == nil {
+		t.Fatal("enter on a staged size must return the apply command")
+	}
+	var act tea.Msg
+	if batch, ok := cmd().(tea.BatchMsg); ok { // Batch wraps, doesn't run
+		for _, c := range batch {
+			if msg, ok := c().(poolActMsg); ok {
+				act = msg
+			}
+		}
+	}
+	if applied != 2 || act == nil {
+		t.Fatalf("apply must call PoolSet with the staged size, got applied=%d msg=%v", applied, act)
+	}
+	got, _ = m.Update(act)
+	m = got.(model)
+	if !strings.Contains(m.status, "pool size 2") || m.statusBad {
+		t.Errorf("a landed apply must confirm with the log path, got status=%q", m.status)
+	}
+
+	// Another repo's row can't be sized from here — its checkout is elsewhere.
+	m.poolIdx, m.poolPend = 0, -1
+	got, _ = m.updatePool(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("+")})
+	m = got.(model)
+	if m.poolPend != -1 || !strings.Contains(m.status, "inside other") {
+		t.Errorf("sizing another repo must be refused with a pointer, got pend=%d status=%q", m.poolPend, m.status)
+	}
+}
+
+// Draining destroys money-costing VMs, so d asks y/n first; it works for any
+// repo (no checkout needed) but refuses politely when there's nothing there.
+func TestPoolDrainConfirm(t *testing.T) {
+	drained := ""
+	m := model{loaded: true, mode: modePool,
+		poolRepos: []string{"old"}, poolPend: -1,
+		members: []driver.Session{{Name: "pool-old-x", Repo: "old", State: driver.StateParked, PoolGen: "g", Created: time.Now()}},
+		opts: Options{
+			PoolSizes: func() map[string]int { return nil },
+			Fetch:     func() ([]driver.Session, error) { return nil, nil },
+			PoolDrain: func(repo string) (int, error) { drained = repo; return 1, nil },
+		}}
+	got, _ := m.updatePool(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	m = got.(model)
+	if !m.poolConfirm {
+		t.Fatal("d on a repo with members must ask for confirmation")
+	}
+	if v := m.View(); !strings.Contains(v, "drain old") || !strings.Contains(v, "(y/n)") {
+		t.Errorf("the confirm prompt must name the repo:\n%s", v)
+	}
+	got, _ = m.updatePool(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	m = got.(model)
+	if m.poolConfirm || drained != "" {
+		t.Fatalf("n must cancel the drain, got confirm=%v drained=%q", m.poolConfirm, drained)
+	}
+
+	got, _ = m.updatePool(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	m = got.(model)
+	got, cmd := m.updatePool(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m = got.(model)
+	if cmd == nil {
+		t.Fatal("y must fire the drain")
+	}
+	var act tea.Msg
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if msg, ok := c().(poolActMsg); ok {
+				act = msg
+			}
+		}
+	}
+	if drained != "old" || act == nil {
+		t.Fatalf("drain must target the selected repo, got %q", drained)
+	}
+	got, _ = m.Update(act)
+	m = got.(model)
+	if !strings.Contains(m.status, "drained 1 member") {
+		t.Errorf("a landed drain must report the count, got %q", m.status)
+	}
+
+	m.members, m.poolConfirm, m.status = nil, false, ""
+	got, _ = m.updatePool(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	m = got.(model)
+	if m.poolConfirm || !strings.Contains(m.status, "no warm members") {
+		t.Errorf("d on an empty pool must notice, not prompt, got confirm=%v status=%q", m.poolConfirm, m.status)
+	}
+}
+
 func TestSanitizeLog(t *testing.T) {
 	// pnpm/docker progress spam: color codes plus \r-redrawn meters. Only
 	// each line's final state should survive.

--- a/skills/pier-onboard/SKILL.md
+++ b/skills/pier-onboard/SKILL.md
@@ -115,3 +115,8 @@ the laptop for the VM.
   in the repo (~8 min, once per hook change). Then create a session and
   watch `pier ls` — `(setup running)` should clear; if it shows
   `(setup failed)`, attach and read `~/.pier-setup.log`.
+- If `.pier-setup.sh` is heavy (long installs, docker pulls, migrations),
+  mention `pier pool set <n>`: it keeps n parked, setup-complete sessions
+  ready to claim, so new sessions skip the wait entirely (~$3-4/mo per
+  warm member, disk only). Changing `.pier-setup.sh` later is safe — warm
+  members notice and recycle on the next claim or fill.


### PR DESCRIPTION
## What

Opt-in, per-repo warm pools: N parked, **setup-complete** instances that `pier <branch>` claims — resume + freshen instead of create + boot + full setup. ~30s to attach on AWS with `.pier-setup.sh` already run (vs ~52s + async setup). Parked members cost ~$3–4/mo each (disk only), shown wherever pools appear.

## UX

- `pier pool set 2` (from a repo) turns it on; a detached fill starts immediately.
- `pier <branch>` claims transparently: `claimed warm member pool-shop-a3f9 — resuming` → `session <branch> ready`, then a detached refill tops the pool up. Empty pool → `no warm member to claim — creating fresh`. `--no-pool` bypasses.
- TUI is the primary surface: `w` opens the pools page (per-repo size editing with +/-/enter, `f` fill, `d` drain with confirm, live ready/filling/stale census, honest cost line); the session list header counts warm members. `pier pool` / `set` / `fill` / `drain` are the scriptable equivalents.
- Members never appear as sessions: not in `pier ls`, attach matching, or proxy hostnames. `doctor` flags orphaned and stuck-filling members; `teardown` drains first; `bake` warns that members went stale.

## How

- **Driver seam (minimal):** `CreateSpec.PoolGen`, `Session.PoolGen`, `Claim(ctx, id, ClaimSpec{Name,Branch,Nonce})` + `ErrClaimLost`. Everything else reuses Create/Resume/Park/Destroy/List/Exec/SSHTarget.
- **Member = normal instance + one tag** (`pier:pool=<gen>` / GCE label). `gen` fingerprints driver|image|type|disk|setup-script: re-bake, config change, or setup edit strands the generation → recycled at next claim/fill. `pool.max_age` (default 14d) bounds repo drift.
- **Claim race:** nonce written to a claim tag and read back (no tag CAS on either cloud); the read-back also asserts the pool tag still exists — deleting it is the winner's commit point. Losers try the next member or fall through.
- **No daemon:** all state derives from provider tags/labels. Fills run detached with a 2m supervisor leash (dead laptop → member still self-parks); unparked members past a 2h grace recycle at the next mutating reconcile.
- **Accelerate, never gate:** any claim-path failure (throttled API, member destroyed under us, freshen failure) logs loudly, destroys the untrusted member if needed, and falls back to a fresh create.

## Testing

- `make test` (vet + unit tests: fingerprint, reconcile, claim ordering, tag/label construction, config, TUI pool page/editing/drain flows) and `make build` pass.
- A 28-agent adversarial review produced 24 confirmed findings — all fixed or documented (accepted: seconds-wide drain-vs-claim snapshot race, basename-keyed pools consistent with bake).
- Cloud E2E (fill → claim timings, two-terminal race, recycle-on-rebake) still pending — needs an account decision; will record in SPEC §14.