### PR TITLE
fix(aws): scope instances to Identity Center user

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,10 +439,11 @@ The cloud says "running" long before a session is usable, so pier doesn't:
 ## How it works
 
 A session is one VM plus its persistent disk, tagged and namespaced by your
-caller identity (your STS ARN on AWS, your authed principal on GCP), so a
-team shares one account with zero collisions. All state lives in those tags
-and on the disk. `pier ls` is one filtered describe call, and there is
-nothing else to operate, back up, or pay for.
+caller identity (your complete STS ARN on AWS, including the Identity Center
+user segment of an assumed-role ARN), so a team can share one role without
+sharing instances. All state lives in those tags and on the disk. `pier ls`
+is one filtered describe call, and there is nothing else to operate, back up,
+or pay for.
 
 ```
 laptop                              AWS account (yours)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -130,11 +130,21 @@ for every connection. Teardown deletes the SG, rules included.
 
 ## 5. Identity & teams
 
-The caller's cloud identity (STS `GetCallerIdentity` ARN; GCP authed
-principal) is written to `pier:user` at create and filtered on at list. Many
-devs share one account with zero coordination: no name collisions, no shared
-state, nothing to configure. `pier ls --all` can show teammates' sessions
-(read-only visibility); everything else operates only on your own.
+The caller's cloud identity (the complete STS `GetCallerIdentity` ARN; GCP
+authed principal) is written to `pier:user` at create and filtered on at list.
+For an AWS assumed role, the final role-session segment is retained because it
+identifies the Identity Center user. Many devs can therefore choose the same
+permission-set role without sharing session state or creating name collisions.
+
+AWS instances created by Pier versions that stripped the role-session segment
+have a legacy role-wide `pier:user` tag. The original user cannot be recovered
+from that tag; each owner must retag their existing instances once with their
+complete current `sts get-caller-identity` ARN after identifying their instance:
+
+```sh
+aws ec2 create-tags --resources i-0123456789abcdef0 --tags \
+  Key=pier:user,Value="$(aws sts get-caller-identity --query Arn --output text)"
+```
 
 ## 6. Parking policy (supervisor)
 

--- a/internal/driver/awsec2/driver.go
+++ b/internal/driver/awsec2/driver.go
@@ -74,8 +74,10 @@ var _ driver.Driver = (*Driver)(nil)
 
 func (d *Driver) Name() string { return "aws-ec2" }
 
-// user returns the caller identity used for tag namespacing. Assumed-role
-// ARNs get their per-login session name stripped so the value is stable.
+// user returns the complete caller identity used for tag namespacing. The
+// final segment of an assumed-role ARN is the role-session identity (the
+// Identity Center username/email), so it must remain part of the owner. Two
+// people using the same permission-set role must not share Pier sessions.
 func (d *Driver) user(ctx context.Context) (string, error) {
 	if d.callerARN != "" {
 		return d.callerARN, nil
@@ -84,11 +86,8 @@ func (d *Driver) user(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if i := strings.Index(arn, ":assumed-role/"); i >= 0 {
-		parts := strings.Split(arn, "/")
-		if len(parts) == 3 {
-			arn = strings.Join(parts[:2], "/")
-		}
+	if arn == "" {
+		return "", fmt.Errorf("AWS returned an empty caller identity ARN")
 	}
 	d.callerARN = arn
 	return arn, nil

--- a/internal/driver/awsec2/driver_test.go
+++ b/internal/driver/awsec2/driver_test.go
@@ -1,0 +1,27 @@
+package awsec2
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUserPreservesAssumedRoleSessionIdentity(t *testing.T) {
+	const arn = "arn:aws:sts::123456789012:assumed-role/Developer/alice@example.com"
+	bin := t.TempDir()
+	aws := filepath.Join(bin, "aws")
+	if err := os.WriteFile(aws, []byte("#!/bin/sh\nprintf '%s\\n' '"+arn+"'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	d := Driver{}
+
+	got, err := d.user(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != arn {
+		t.Fatalf("user() = %q, want complete role-session ARN %q", got, arn)
+	}
+}


### PR DESCRIPTION
## Summary

- retain the complete STS assumed-role session ARN so users sharing a permission-set role have separate Pier instance namespaces
- document one-time retagging for legacy role-wide instances
- add regression coverage for assumed-role session identity preservation

## Testing

- make test