### PR TITLE
fix(tui): reauthenticate expired AWS sessions

### DIFF
--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -920,7 +920,7 @@ func confirm(prompt string, def bool) bool {
 // --- TUI --------------------------------------------------------------------------
 
 func cmdTUI() {
-	_, drv := loadDriver()
+	cfg, drv := loadDriver()
 	err := tui.Run(tui.Options{
 		// Async: the TUI opens instantly and the quota fills in when it lands.
 		FetchQuota: func() string {
@@ -937,6 +937,14 @@ func cmdTUI() {
 			}
 			enrich(drv, sessions)
 			return sessions, nil
+		},
+		AuthExpired: awsec2.LoginExpired,
+		Reauthenticate: func() *exec.Cmd {
+			args := []string{"login"}
+			if cfg.AWS.Profile != "" {
+				args = append(args, "--profile", cfg.AWS.Profile)
+			}
+			return exec.Command("aws", args...)
 		},
 		Destroy: func(s driver.Session) error {
 			return drv.Destroy(context.Background(), s.ID)

--- a/internal/driver/awsec2/cli.go
+++ b/internal/driver/awsec2/cli.go
@@ -31,6 +31,18 @@ func (d *Driver) aws(ctx context.Context, args ...string) (string, error) {
 	return strings.TrimSpace(out.String()), nil
 }
 
+// LoginExpired recognizes the AWS CLI's opt-in login session expiry. These
+// credentials are renewed with `aws login` (distinct from Identity Center's
+// `aws sso login`), so callers can offer the right interactive recovery
+// without treating every AWS error as an authentication problem.
+func LoginExpired(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "session has expired") && strings.Contains(msg, "aws login")
+}
+
 // --- SSH into the session ----------------------------------------------------
 // One mechanism for everything interactive and file-shaped: OpenSSH. No
 // standing keys — each session gets its own keypair at create, stored under

--- a/internal/driver/awsec2/driver_test.go
+++ b/internal/driver/awsec2/driver_test.go
@@ -2,10 +2,27 @@ package awsec2
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestLoginExpired(t *testing.T) {
+	err := errors.New("aws sts get-caller-identity: aws: [ERROR]: Your session has expired. Please reauthenticate using 'aws login'.")
+	if !LoginExpired(err) {
+		t.Fatal("the AWS login expiry must be recoverable")
+	}
+	for _, err := range []error{
+		nil,
+		errors.New("aws ec2 describe-instances: access denied"),
+		errors.New("The SSO session associated with this profile has expired or is otherwise invalid"),
+	} {
+		if LoginExpired(err) {
+			t.Errorf("LoginExpired(%v) = true; only `aws login` expiry is supported", err)
+		}
+	}
+}
 
 func TestUserPreservesAssumedRoleSessionIdentity(t *testing.T) {
 	const arn = "arn:aws:sts::123456789012:assumed-role/Developer/alice@example.com"

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -27,8 +27,13 @@ import (
 type Options struct {
 	FetchQuota func() string // e.g. "12/32 vCPUs in use"; nil/"" hides it
 	Fetch      func() ([]driver.Session, error)
-	Destroy    func(driver.Session) error
-	Pin        func(driver.Session) error
+	// AuthExpired identifies a fetch error that an interactive login can fix;
+	// Reauthenticate builds that foreground login command. Together they make
+	// enter recover the list in place instead of forcing a trip back to shell.
+	AuthExpired    func(error) bool
+	Reauthenticate func() *exec.Cmd
+	Destroy        func(driver.Session) error
+	Pin            func(driver.Session) error
 	// CreateDetached starts a background create and returns its log path;
 	// the TUI stays open and the session appears in the list as "creating".
 	// nil disables creating from the TUI (tests).
@@ -83,9 +88,13 @@ type model struct {
 	statusBad bool   // status is an error (red) vs a notice (accent)
 	loading   bool
 	loaded    bool // first fetch has landed
-	polling   bool // an auto-refresh poll is scheduled (creates in flight)
-	watch     int  // poll rounds left after a spawn (until it's listable)
-	frame     int  // spinner frame
+	// recoverable authentication state; while required, enter runs the
+	// foreground provider login instead of acting on a session row
+	authRequired     bool
+	reauthenticating bool
+	polling          bool // an auto-refresh poll is scheduled (creates in flight)
+	watch            int  // poll rounds left after a spawn (until it's listable)
+	frame            int  // spinner frame
 	// attach-in-flight state; enter is a no-op while attachSess is set
 	attachSess    driver.Session // row being attached; zero Name = none in flight
 	attachStart   time.Time      // last ExecProcess launch; feeds RetryAttach
@@ -163,6 +172,9 @@ type reachableMsg struct {
 	err error
 }
 
+// reauthenticatedMsg arrives after the foreground cloud login exits.
+type reauthenticatedMsg struct{ err error }
+
 func tickCmd() tea.Cmd {
 	return tea.Tick(120*time.Millisecond, func(time.Time) tea.Msg { return tickMsg{} })
 }
@@ -190,9 +202,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = false
 		m.loaded = true
 		if msg.err != nil {
+			m.authRequired = m.opts.AuthExpired != nil && m.opts.AuthExpired(msg.err)
 			m.status, m.statusBad = msg.err.Error(), true
 			return m, nil
 		}
+		m.authRequired = false
 		m.sessions = msg.sessions
 		if m.cursor >= len(m.sessions) {
 			m.cursor = max(0, len(m.sessions)-1)
@@ -276,6 +290,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m.startAttach(msg.s) // second and final attempt; attachRetried stays set
+	case reauthenticatedMsg:
+		m.reauthenticating = false
+		if msg.err != nil {
+			m.status, m.statusBad = "reauthentication failed: "+msg.err.Error(), true
+			return m, nil
+		}
+		m.authRequired = false
+		m.loaded, m.loading = false, true
+		m.status, m.statusBad = "authenticated — refreshing sessions…", false
+		return m, tea.Batch(m.fetch, tickCmd())
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		if m.mode == modeLogs {
@@ -331,6 +355,27 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Expired auth is a focused recovery state: enter temporarily hands the
+	// terminal to the provider login, then a successful login refetches the
+	// list. Keep the original error visible until that happens.
+	if m.authRequired {
+		switch msg.String() {
+		case "q", "ctrl+c", "esc":
+			return m, tea.Quit
+		case "enter":
+			if m.reauthenticating || m.opts.Reauthenticate == nil {
+				return m, nil
+			}
+			cmd := m.opts.Reauthenticate()
+			if cmd == nil {
+				return m, nil
+			}
+			m.reauthenticating = true
+			m.status, m.statusBad = "reauthenticating…", false
+			return m, tea.ExecProcess(cmd, func(err error) tea.Msg { return reauthenticatedMsg{err} })
+		}
+		return m, nil
+	}
 	m.status = ""
 	switch msg.String() {
 	case "q", "ctrl+c", "esc":
@@ -723,6 +768,8 @@ func (m model) View() string {
 	b.WriteString("\n" + head + "\n\n")
 
 	switch {
+	case m.authRequired:
+		b.WriteString(ui.Dim.Render("   session list unavailable — reauthenticate to continue") + "\n")
 	case !m.loaded:
 		b.WriteString(ui.Dim.Render("   fetching sessions…") + "\n")
 	case len(m.sessions) == 0:
@@ -763,7 +810,11 @@ func (m model) View() string {
 				b.WriteString(" " + ui.Accent.Render("▸ "+m.status) + "\n")
 			}
 		}
-		b.WriteString(" " + ui.Keys("enter", "attach", "n", "new", "d", "delete", "p", "pin", "m", "resize", "l", "logs", "s", "settings", "r", "refresh", "q", "quit") + "\n")
+		if m.authRequired {
+			b.WriteString(" " + ui.Keys("enter", "reauthenticate", "q", "quit") + "\n")
+		} else {
+			b.WriteString(" " + ui.Keys("enter", "attach", "n", "new", "d", "delete", "p", "pin", "m", "resize", "l", "logs", "s", "settings", "r", "refresh", "q", "quit") + "\n")
+		}
 	}
 	return b.String()
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -43,6 +43,61 @@ func TestViewStates(t *testing.T) {
 	}
 }
 
+func TestEnterReauthenticatesExpiredCloudSession(t *testing.T) {
+	expired := errors.New("aws sts get-caller-identity: your session has expired; use aws login")
+	logins, fetches := 0, 0
+	m := model{opts: Options{
+		AuthExpired: func(err error) bool { return strings.Contains(err.Error(), "session has expired") },
+		Reauthenticate: func() *exec.Cmd {
+			logins++
+			return exec.Command("true")
+		},
+		Fetch: func() ([]driver.Session, error) {
+			fetches++
+			return []driver.Session{{Name: "fix-auth", State: driver.StateRunning}}, nil
+		},
+	}}
+
+	got, _ := m.Update(sessionsMsg{err: expired})
+	m = got.(model)
+	view := m.View()
+	if !m.authRequired || !strings.Contains(view, "enter") || !strings.Contains(view, "reauthenticate") || strings.Contains(view, "no sessions") {
+		t.Fatalf("expired auth must offer enter-to-reauthenticate:\n%s", view)
+	}
+
+	got, cmd := m.updateList(tea.KeyMsg{Type: tea.KeyEnter})
+	m = got.(model)
+	if cmd == nil || logins != 1 || !m.reauthenticating {
+		t.Fatalf("enter must build the foreground login, got cmd=%v logins=%d running=%v", cmd, logins, m.reauthenticating)
+	}
+
+	got, cmd = m.Update(reauthenticatedMsg{})
+	m = got.(model)
+	if cmd == nil || m.authRequired || !m.loading || !strings.Contains(m.status, "refreshing") {
+		t.Fatalf("successful login must start a refresh, got auth=%v loading=%v status=%q", m.authRequired, m.loading, m.status)
+	}
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c != nil {
+				c()
+			}
+		}
+	}
+	if fetches != 1 {
+		t.Errorf("successful login fetched %d times, want 1", fetches)
+	}
+}
+
+func TestFailedReauthenticationCanRetry(t *testing.T) {
+	m := model{authRequired: true, reauthenticating: true,
+		opts: Options{Reauthenticate: func() *exec.Cmd { return exec.Command("true") }}}
+	got, _ := m.Update(reauthenticatedMsg{err: errors.New("exit status 1")})
+	m = got.(model)
+	if !m.authRequired || m.reauthenticating || !m.statusBad || !strings.Contains(m.View(), "reauthenticate") {
+		t.Fatalf("failed login must preserve the retry action, got auth=%v running=%v status=%q", m.authRequired, m.reauthenticating, m.status)
+	}
+}
+
 // The settings page groups fields under human labels, shows the current
 // values, surfaces the read-only "managed elsewhere" section, and explains
 // the selected field in the detail footer.


### PR DESCRIPTION
When the AWS CLI login session expires during Pier’s initial fetch, the TUI currently leaves the user at an unactionable error. Detect the specific `aws login` expiry, offer Enter as a reauthentication action, run the login with the configured profile, and refresh the session list afterward. Other AWS failures and expired SSO sessions remain untouched so Pier does not suggest the wrong recovery command.

Tests cover expiry detection, successful login/refetch, retry after a failed login, and the recovery-state rendering.

Checks: `make test`; `make build`