### PR TITLE
docs: add commit message guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Commit Messages
+
+- Use `<type>(<optional-scope>): <description>` with one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+- Keep descriptions concise, lowercase, imperative, and without a trailing period.
+- Mark breaking changes with `!` before the colon and a `BREAKING CHANGE:` footer.


### PR DESCRIPTION
Adds concise Conventional Commit guidance for agents, including allowed types and breaking-change notation.