### PR TITLE
ci: run race detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           fi
       - name: vet and test
         run: make test
+      - name: race detector
+        run: go test -race ./...
       # make, not go build: session creation fails at runtime if the
       # cross-compiled supervisors don't embed
       - name: build


### PR DESCRIPTION
## Why

Pier has several concurrent execution paths, but the race detector was not part of the regular CI checks. This adds it as a dedicated step so race failures are clearly visible on pull requests and `main`, while preserving the existing test, build, smoke, and release workflows.

## Validation

- `go test -race ./...`
- `make test`
- `make build`
- `actionlint .github/workflows/*.yml`

Closes #15

AI disclosure: This change was prepared with assistance from OpenAI Codex.