### PR TITLE
docs: add issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug Report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please avoid pasting credentials, tokens, or unredacted config — redact anything sensitive before submitting.
+
+  - type: input
+    id: pier-version
+    attributes:
+      label: Pier version
+      description: Output of `pier version`
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Provider
+      options:
+        - AWS
+        - GCP
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: local-os
+    attributes:
+      label: Local OS
+      description: e.g. macOS 14, Ubuntu 22.04
+    validations:
+      required: true
+
+  - type: input
+    id: region-zone
+    attributes:
+      label: Region / zone
+    validations:
+      required: false
+
+  - type: dropdown
+    id: connection-mode
+    attributes:
+      label: Connection mode
+      options:
+        - SSH
+        - Session Manager (AWS)
+        - Other / not sure
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you run, in order?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant output. Redact credentials, tokens, or unredacted config before pasting.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature / Design Proposal
+description: Propose a new feature or a change to Pier's design
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For anything beyond a minor fix, please open an issue first to discuss the design before sending a PR — see CONTRIBUTING.md.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    id: design-alignment
+    attributes:
+      label: How does this align with Pier's documented design constraints?
+      description: e.g. VMs never hold cloud credentials, parking is self-initiated laptop-side, etc. Reference the design doc if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ## Checklist
 
-- [ ] `gofmt` and `go vet ./...` pass
+- [ ] `gofmt -l .` produces no output and `go vet ./...` passes
 - [ ] `make build` succeeds (if this touches supervisor/session code)
 - [ ] Tests added or updated for behavior changes
 - [ ] Docs updated if applicable

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What does this PR do and why?
+
+<!-- One paragraph explaining the rationale. -->
+
+## Related issue
+
+<!-- Closes #... if applicable. Non-trivial changes should have a discussed issue first. -->
+
+## Tests
+
+<!-- What did you add or run? `go test ./...` output if relevant. -->
+
+## Checklist
+
+- [ ] `gofmt` and `go vet ./...` pass
+- [ ] `make build` succeeds (if this touches supervisor/session code)
+- [ ] Tests added or updated for behavior changes
+- [ ] Docs updated if applicable

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist/
 .DS_Store
 cmd/pier/assets/pier-supervisor-*
+.idea/


### PR DESCRIPTION
Adds GitHub issue forms (bug report, feature/design proposal) and a PR template, as requested in #16.

Closes #16 