### PR TITLE
ci: fold the race detector into make test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
           fi
       - name: vet and test
         run: make test
-      - name: race detector
-        run: go test -race ./...
       # make, not go build: session creation fails at runtime if the
       # cross-compiled supervisors don't embed
       - name: build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ change is to keep it that way.
 ```
 make          # cross-compiles the in-VM supervisor, embeds it, builds ./pier
 make install  # install to $(go env GOPATH)/bin
-go test ./...
+make test     # go vet + go test -race
 ```
 
 Always build with `make`, not `go build` — the supervisor binaries must be

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install: build
 	install -m 0755 pier $$(go env GOPATH)/bin/pier
 
 test:
-	go vet ./... && go test ./...
+	go vet ./... && go test -race ./...
 
 clean:
 	rm -f pier $(ASSETS)/pier-supervisor-linux-*


### PR DESCRIPTION
Folds `-race` into the default `make test` target and removes the separate CI step added in #25, so the suite compiles and runs once instead of twice and local `make test` catches races too. The instrumented suite runs in under ten seconds from a cold cache.

Branched from #25; intended to merge after it.