### PR TITLE
feat(config): consolidate repo config under .pier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,8 @@ open decisions — TODOs in code point there. The short version:
   every install step is guarded so it no-ops when the image already has it.
   Guards must test something the stock image *lacks*.
 - **Images are toolchains, sessions are state.** `pier bake` and
-  `.pier-bake.sh` install tools; repo state (deps, migrations, env) belongs
-  in `.pier-setup.sh` at session boot. pier does not chase language
+  `.pier/bake.sh` install tools; repo state (deps, migrations, env) belongs
+  in `.pier/setup.sh` at session boot. pier does not chase language
   ecosystems in its default image.
 - **Failures are loud.** Setup outcomes, bake failures, unreachable
   sessions — every failure names itself and says where to look next.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ resuming checkout-flow (~20-60s)...
 
 ## Making your repo pier-ready
 
-Pier uses one local, gitignored `.pier/` directory with three optional files:
+Pier uses one committed `.pier/` directory with three optional files:
 
 | File | Runs / read | Contains |
 |---|---|---|
@@ -249,9 +249,8 @@ Pier uses one local, gitignored `.pier/` directory with three optional files:
 | `.pier/include` | At create | Untracked/ignored files to carry (env files, local certs) |
 | `.pier/bake.sh` | Once, during `pier bake` | Toolchains beyond the default image (pnpm, python, rust, ...) |
 
-Add `/.pier/` to the repository's `.gitignore`. Pier reads these files from
-the laptop and explicitly carries the selected setup script into each new
-session.
+Do not ignore `.pier/`: it is shared project configuration. Loose local files
+listed in `.pier/include`, such as `.env`, should remain in `.gitignore`.
 
 ```bash
 # .pier/setup.sh (cwd is the repo root, logs to ~/.pier-setup.log)
@@ -287,8 +286,8 @@ COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install -g pnpm@10.6.5
 
 Don't write those files by hand. This repo ships
 [`skills/pier-onboard`](skills/pier-onboard/SKILL.md), a skill that teaches
-a coding agent to inspect your repo, update `.gitignore`, and write all three
-files with the right boundaries.
+a coding agent to inspect your repo, write all three files with the right
+boundaries, and keep loose local files protected by `.gitignore`.
 
 ```
 cp -r pier/skills/pier-onboard ~/.claude/skills/    # or your repo's .claude/skills/

--- a/README.md
+++ b/README.md
@@ -241,16 +241,20 @@ resuming checkout-flow (~20-60s)...
 
 ## Making your repo pier-ready
 
-Three optional files at the repo root, all committed:
+Pier uses one local, gitignored `.pier/` directory with three optional files:
 
 | File | Runs / read | Contains |
 |---|---|---|
-| `.pier-setup.sh` | Every session's first boot, async, in a `setup` tmux window | Repo state: deps, services, migrations, seeds |
-| `.pier-include` | At create | Untracked/ignored files to carry (env files, local certs) |
-| `.pier-bake.sh` | Once, during `pier bake` | Toolchains beyond the default image (pnpm, python, rust, ...) |
+| `.pier/setup.sh` | Every session's first boot, async, in a `setup` tmux window | Repo state: deps, services, migrations, seeds |
+| `.pier/include` | At create | Untracked/ignored files to carry (env files, local certs) |
+| `.pier/bake.sh` | Once, during `pier bake` | Toolchains beyond the default image (pnpm, python, rust, ...) |
+
+Add `/.pier/` to the repository's `.gitignore`. Pier reads these files from
+the laptop and explicitly carries the selected setup script into each new
+session.
 
 ```bash
-# .pier-setup.sh (cwd is the repo root, logs to ~/.pier-setup.log)
+# .pier/setup.sh (cwd is the repo root, logs to ~/.pier-setup.log)
 set -euo pipefail
 pnpm install
 docker compose up -d
@@ -262,7 +266,7 @@ fully detach with `setsid cmd </dev/null >log 2>&1 &` or it dies when the
 setup window closes.
 
 ```
-# .pier-include: one path or glob per line (no **), a directory carries its subtree
+# .pier/include: one path or glob per line (no **), a directory carries its subtree
 .env
 apps/*/.env.local
 ```
@@ -272,7 +276,7 @@ contents arrive as a regular file at the symlink's repository path. Directory
 symlinks are never followed.
 
 ```bash
-# .pier-bake.sh (agent user, passwordless sudo, NO repo checkout yet)
+# .pier/bake.sh (agent user, passwordless sudo, NO repo checkout yet)
 set -euo pipefail
 sudo corepack enable
 echo COREPACK_ENABLE_DOWNLOAD_PROMPT=0 | sudo tee -a /etc/environment >/dev/null
@@ -283,8 +287,8 @@ COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install -g pnpm@10.6.5
 
 Don't write those files by hand. This repo ships
 [`skills/pier-onboard`](skills/pier-onboard/SKILL.md), a skill that teaches
-a coding agent to inspect your repo and write all three files with the right
-boundaries.
+a coding agent to inspect your repo, update `.gitignore`, and write all three
+files with the right boundaries.
 
 ```
 cp -r pier/skills/pier-onboard ~/.claude/skills/    # or your repo's .claude/skills/
@@ -317,7 +321,7 @@ when you do).
 Secrets travel once, at create, as an explicit manifest:
 
 - `~/.claude`, `~/.codex`, tokens (`gh auth token`, `claude setup-token`)
-- the repo files your `.pier-include` lists
+- the repo files your `.pier/include` lists
 
 Nothing loose ships by default. The create prints which env files it is
 *not* carrying. The VM never holds cloud credentials. On AWS its instance
@@ -365,7 +369,7 @@ A stock create installs the harnesses under cloud-init, which takes minutes.
 Baking pays that cost once:
 
 ```
-pier bake    # one throwaway instance + your .pier-bake.sh, snapshotted as an image
+pier bake    # one throwaway instance + your .pier/bake.sh, snapshotted as an image
 ```
 
 Creates from a baked image drop to a minute or two. Images are keyed to
@@ -374,8 +378,8 @@ supersedes the old image, and `pier teardown` sweeps them all by tag.
 
 ### Setup that can't fail silently
 
-`.pier-setup.sh` runs async in its own tmux window on first boot, after the
-checkout, dirty patch, and `.pier-include` files are in place. The outcome
+`.pier/setup.sh` runs async in its own tmux window on first boot, after the
+checkout, dirty patch, and `.pier/include` files are in place. The outcome
 always surfaces:
 
 - `pier ls` and the TUI show `(setup running)` or `(setup failed)`
@@ -435,7 +439,7 @@ The cloud says "running" long before a session is usable, so pier doesn't:
 - **GCP wakes slower than AWS.** Resume to attached is about a minute
   against EC2's ~20s, and a running resize takes about two minutes. GCE
   stop/start simply takes longer.
-- **Bake hooks live only in baked images.** A repo with a `.pier-bake.sh`
+- **Bake hooks live only in baked images.** A repo with a `.pier/bake.sh`
   that was never baked runs stock. Setup then fails loudly, not silently.
 - **Resize stays within the CPU arch** (t4g to t4g). Providers only allow
   type changes on stopped instances.
@@ -502,7 +506,7 @@ The choices contributors should know before proposing changes
   install step is a no-op when the image already has it. Baking is an
   optimization, never a requirement.
 - **Images are toolchains, sessions are state.** `pier bake` installs
-  tools. Deps, migrations, and env belong to `.pier-setup.sh` at boot.
+  tools. Deps, migrations, and env belong to `.pier/setup.sh` at boot.
 - **Dirty state travels as a git patch,** not rsync. Binary-safe,
   reviewable, applied atomically after checkout.
 - **Truth over optimism in states.** The ready tag, the setup status file,

--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -867,7 +867,7 @@ func cmdBake() {
 	fmt.Printf("%s %s\n", ui.Bold.Render("baking "+name),
 		ui.Dim.Render("(one temporary instance ~5 min, then an image — ~$1-2/mo storage)"))
 	if hook != "" {
-		fmt.Println(ui.Step(".pier-bake.sh found — its toolchains bake in"))
+		fmt.Println(ui.Step(".pier/bake.sh found — its toolchains bake in"))
 	}
 	// This bake supersedes the repo's previous image (and on aws-ec2, once
 	// per config, the legacy shared one).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -19,7 +19,7 @@ pier                    # TUI: sessions + states; pick one to reattach (~30-60s 
 ```
 
 A session comes prepacked with: the repo on a fresh branch, the dev
-environment (repo's local `.pier/setup.sh`, run automatically), the user's
+environment (repo's `.pier/setup.sh`, run automatically), the user's
 secrets (one-way copy from the laptop), and both agent harnesses installed.
 Everything else is bloat.
 
@@ -258,11 +258,11 @@ Targets: **create → attached 60–90s; resume → attached ~30s** (measured
 numbers in §14; GCP runs about a minute behind AWS on each — GCE stop/start
 and the IAP tunnel are simply slower).
 
-Repo-specific Pier config lives locally under `.pier/`, with `/.pier/` in
-the repository's `.gitignore`. Create reads `.pier/include` on the laptop and
-explicitly puts the selected `.pier/setup.sh` into the files tar; bake reads
-`.pier/bake.sh` directly. The config directory therefore stays local without
-depending on the git checkout that lands on the VM.
+Repo-specific Pier config is committed under `.pier/`; the directory must not
+be ignored. Create reads `.pier/include` on the laptop, `.pier/setup.sh`
+arrives with the git checkout, and bake reads `.pier/bake.sh` directly. Loose
+local files named by `.pier/include` stay protected by the repository's
+`.gitignore`.
 
 1. **`pier bake`** — prebaked **per-repo** image: agent user, tmux, git, gh,
    docker (with compose + buildx — docker.io alone is the bare engine; the

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -19,9 +19,9 @@ pier                    # TUI: sessions + states; pick one to reattach (~30-60s 
 ```
 
 A session comes prepacked with: the repo on a fresh branch, the dev
-environment (repo's `.pier-setup.sh`, run automatically), the user's secrets
-(one-way copy from the laptop), and both agent harnesses installed. Everything
-else is bloat.
+environment (repo's local `.pier/setup.sh`, run automatically), the user's
+secrets (one-way copy from the laptop), and both agent harnesses installed.
+Everything else is bloat.
 
 **Hard requirements:** runs on AWS *and* GCP easily; scale-to-(near)zero with
 pick-back-up; one-command TUI; one-time wizard setup; teams share an account
@@ -185,7 +185,7 @@ A session either exists fully set up or not at all — no half-states:
 
 - The create's **last act** is a `pier:ready` tag on the instance (written
   after the VM-side bootstrap touches `~/.pier-bootstrapped`; the marker
-  stays as the raw-ssh backstop, before the async `.pier-setup.sh`
+  stays as the raw-ssh backstop, before the async `.pier/setup.sh`
   finishes). EC2 reports `running` well before the session is usable — SSM
   registration alone lags ~30s — so ls/TUI read running-without-the-tag as
   `creating`: truthful state from the first second, no probe, no SSM
@@ -258,6 +258,12 @@ Targets: **create → attached 60–90s; resume → attached ~30s** (measured
 numbers in §14; GCP runs about a minute behind AWS on each — GCE stop/start
 and the IAP tunnel are simply slower).
 
+Repo-specific Pier config lives locally under `.pier/`, with `/.pier/` in
+the repository's `.gitignore`. Create reads `.pier/include` on the laptop and
+explicitly puts the selected `.pier/setup.sh` into the files tar; bake reads
+`.pier/bake.sh` directly. The config directory therefore stays local without
+depending on the git checkout that lands on the VM.
+
 1. **`pier bake`** — prebaked **per-repo** image: agent user, tmux, git, gh,
    docker (with compose + buildx — docker.io alone is the bare engine; the
    daemon runs userns-remapped to agent, so container-root writes on bind
@@ -266,9 +272,9 @@ and the IAP tunnel are simply slower).
    files), make,
    claude + codex, headless chromium (playwright build + system
    deps, for browser MCPs/skills), supervisor preinstalled — plus whatever
-   the repo's `.pier-bake.sh` installs on top (run on the bake instance as
+   the repo's `.pier/bake.sh` installs on top (run on the bake instance as
    agent with passwordless sudo, no repo checkout present: toolchains like
-   pnpm/python belong here, repo state in `.pier-setup.sh`; a failed hook
+   pnpm/python belong here, repo state in `.pier/setup.sh`; a failed hook
    aborts the bake). Pier deliberately doesn't chase language ecosystems in
    the default image — the hook is the user's channel. Images are keyed by
    repo basename in config (`[aws.baked_amis]` / `[gcp.baked_images]`),
@@ -279,9 +285,9 @@ and the IAP tunnel are simply slower).
    a repo; `pier bake` refreshes it.
 2. **Overlapped create** — launch the instance first; build the git bundle +
    secrets tar while it boots; push and bootstrap the moment sshd answers;
-   `.pier-setup.sh` runs asynchronously in a background tmux window while you
+   `.pier/setup.sh` runs asynchronously in a background tmux window while you
    type to the agent — it starts only after the checkout, dirty patch, and
-   `.pier-include` extras are all in place. `PIER_SETUP_SCRIPT`
+   `.pier/include` extras are all in place. `PIER_SETUP_SCRIPT`
    points it at a different script — relative to the repo root or `~` —
    which travels in the tar and takes precedence over the repo's own.
    The outcome is never silent: the window writes `~/.pier-setup.status`
@@ -313,7 +319,7 @@ and the IAP tunnel are simply slower).
    session's working tree starts exactly as the laptop's, staged edits
    arriving unstaged. (Only when the session's base is the laptop's HEAD; a
    session created off another commit carries no dirty state.) Untracked and
-   ignored files travel **only** when a repo-root **`.pier-include`** names
+   ignored files travel **only** when **`.pier/include`** names
    them: one path or glob per line, matched against the disk with no
    git-status distinction — listed = travels, extracted after checkout +
    patch so listed content wins. Directly matched file symlinks are
@@ -330,7 +336,7 @@ quota polling.
 One-way copy from the laptop at create; never stored anywhere else, never
 written back. Sources (wizard-detected, confirmed into the manifest):
 
-- repo files named by a repo-root `.pier-include` (path or glob per line) —
+- repo files named by `.pier/include` (path or glob per line) —
   the **only** loose-file channel: nothing untracked or ignored ships without
   a line here (env files included; the create warns about ones left behind).
   Directly matched file symlinks carry their target contents under the link's

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -4,7 +4,7 @@
 #
 # vhs drives a real terminal, so this records against real sessions.
 # Stage before recording: a throwaway repo (e.g. /tmp/pier-demo/shop) whose
-# .pier-setup.sh starts a dev server on :3000, then
+# .pier/setup.sh starts a dev server on :3000, then
 #   pier checkout-flow -d --no-park
 #   pier search-index  -d --no-park
 # Both must be past creating (harness installed, claude authenticated —

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ type AWS struct {
 	// used as a fallback, deregistered and cleared by the next `pier bake`.
 	BakedAMI string `toml:"baked_ami,omitempty"`
 	// BakedAMIs: repo basename -> image, written by `pier bake` (run from the
-	// repo). Each repo bakes its own image so .pier-bake.sh toolchains don't
+	// repo). Each repo bakes its own image so .pier/bake.sh toolchains don't
 	// bleed across projects.
 	BakedAMIs map[string]string `toml:"baked_amis,omitempty"`
 }
@@ -47,14 +47,14 @@ type GCP struct {
 	MachineType string `toml:"machine_type"`
 	DiskGiB     int    `toml:"disk_gib"`
 	// BakedImages: repo basename -> image, written by `pier bake` (run from
-	// the repo). Each repo bakes its own image so .pier-bake.sh toolchains
+	// the repo). Each repo bakes its own image so .pier/bake.sh toolchains
 	// don't bleed across projects.
 	BakedImages map[string]string `toml:"baked_images,omitempty"`
 }
 
 type Secrets struct {
 	// Manifest: files/dirs under $HOME copied one-way into each session's
-	// home at create. Repo files listed in a repo-root .pier-include travel
+	// home at create. Repo files listed in .pier/include travel
 	// additionally (uncommitted tracked edits ride separately, as a patch).
 	Manifest []string `toml:"manifest"`
 	// ClaudeOAuthToken: from `claude setup-token` (macOS Keychain escape

--- a/internal/driver/awsec2/bake.go
+++ b/internal/driver/awsec2/bake.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Bake launches a throwaway instance with the exact session user-data, lets
-// cloud-init finish the harness install, runs the repo's .pier-bake.sh (if
+// cloud-init finish the harness install, runs the repo's .pier/bake.sh (if
 // any), and images the result. Because every install step in the user-data is
 // guarded, sessions launched from the baked AMI skip straight past it — cold
 // create drops to boot + push time (~60-90s). Images are repo-specific: the
@@ -81,12 +81,12 @@ exit 1`
 		return "", fmt.Errorf("harness install did not complete: %w", err)
 	}
 	if spec.HookPath != "" {
-		fmt.Println(ui.Step("running .pier-bake.sh (output follows)"))
+		fmt.Println(ui.Step("running .pier/bake.sh (output follows)"))
 		if err := d.scpTo(ctx, id, spec.HookPath, "/tmp/pier-bake.sh", "-q"); err != nil {
 			return "", err
 		}
 		if err := d.sshStream(ctx, id, "bash /tmp/pier-bake.sh && rm -f /tmp/pier-bake.sh"); err != nil {
-			return "", fmt.Errorf(".pier-bake.sh failed — nothing baked: %w", err)
+			return "", fmt.Errorf(".pier/bake.sh failed — nothing baked: %w", err)
 		}
 	}
 	// Per-instance state must not leak into the image.

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -55,7 +55,7 @@ type Machine struct {
 }
 
 // CreateSpec describes a new session. Create returns as soon as the instance
-// is attach-ready; code push and .pier-setup.sh continue asynchronously in
+// is attach-ready; code push and .pier/setup.sh continue asynchronously in
 // the session (the async create pipeline) with steps streamed via Progress.
 type CreateSpec struct {
 	Name          string
@@ -70,18 +70,18 @@ type CreateSpec struct {
 
 // BakeSpec describes one repo's image bake. Images are repo-specific: the
 // default install serves pier and the harnesses; whatever a repo's toolchain
-// needs on top (pnpm, python, ...) comes from its .pier-bake.sh.
+// needs on top (pnpm, python, ...) comes from its .pier/bake.sh.
 type BakeSpec struct {
 	RepoName string   // repo basename; keys the image to its repo
-	HookPath string   // local path to the repo's .pier-bake.sh; "" = none
+	HookPath string   // local path to the repo's .pier/bake.sh; "" = none
 	Replaces []string // images this bake supersedes (previous bake, legacy shared image)
 }
 
-// BakeHook returns the repo's .pier-bake.sh, "" when absent. It runs on the
+// BakeHook returns the repo's .pier/bake.sh, "" when absent. It runs on the
 // bake instance (agent user, passwordless sudo, no repo checkout — bake
-// predates any session): toolchains belong here, repo state in .pier-setup.sh.
+// predates any session): toolchains belong here, repo state in .pier/setup.sh.
 func BakeHook(repoRoot string) string {
-	p := filepath.Join(repoRoot, ".pier-bake.sh")
+	p := filepath.Join(repoRoot, ".pier", "bake.sh")
 	if fi, err := os.Stat(p); err != nil || !fi.Mode().IsRegular() {
 		return ""
 	}
@@ -159,7 +159,7 @@ type Driver interface {
 	Exec(ctx context.Context, id string, command string) (string, error)
 
 	// Bake builds one repo's prebaked session image (harnesses + the repo's
-	// .pier-bake.sh toolchains), cutting that repo's cold create to ~60-90s.
+	// .pier/bake.sh toolchains), cutting that repo's cold create to ~60-90s.
 	Bake(ctx context.Context, spec BakeSpec) (imageID string, err error)
 
 	// Headroom reports account capacity (vCPU quota) for the create-time

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -1,0 +1,25 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBakeHookUsesPierDirectory(t *testing.T) {
+	root := t.TempDir()
+	if got := BakeHook(root); got != "" {
+		t.Fatalf("BakeHook() without config = %q", got)
+	}
+	configDir := filepath.Join(root, ".pier")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hook := filepath.Join(configDir, "bake.sh")
+	if err := os.WriteFile(hook, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := BakeHook(root); got != hook {
+		t.Fatalf("BakeHook() = %q, want %q", got, hook)
+	}
+}

--- a/internal/driver/gcpgce/bake.go
+++ b/internal/driver/gcpgce/bake.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Bake launches a throwaway instance with the exact session user-data, lets
-// cloud-init finish the harness install, runs the repo's .pier-bake.sh (if
+// cloud-init finish the harness install, runs the repo's .pier/bake.sh (if
 // any), and images the boot disk. Because every install step in the user-data
 // is guarded, sessions launched from the baked image skip straight past it —
 // cold create drops to boot + push time. Images are repo-specific: the hook
@@ -71,12 +71,12 @@ exit 1`
 		return "", fmt.Errorf("harness install did not complete: %w", err)
 	}
 	if spec.HookPath != "" {
-		fmt.Println(ui.Step("running .pier-bake.sh (output follows)"))
+		fmt.Println(ui.Step("running .pier/bake.sh (output follows)"))
 		if err := d.scpTo(ctx, id, spec.HookPath, "/tmp/pier-bake.sh", "-q"); err != nil {
 			return "", err
 		}
 		if err := d.sshStream(ctx, id, "bash /tmp/pier-bake.sh && rm -f /tmp/pier-bake.sh"); err != nil {
-			return "", fmt.Errorf(".pier-bake.sh failed — nothing baked: %w", err)
+			return "", fmt.Errorf(".pier/bake.sh failed — nothing baked: %w", err)
 		}
 	}
 	// Per-instance state must not leak into the image.

--- a/internal/driver/payload/files.go
+++ b/internal/driver/payload/files.go
@@ -236,11 +236,10 @@ func setupScriptOverride(repoRoot string) (path, warn string) {
 }
 
 // buildFilesTar packs, into one tar: manifest files/dirs under $HOME (prefix
-// home/), the repo files named by .pier/include plus the ignored
-// .pier/setup.sh (relative paths kept, prefix repo/), a PIER_SETUP_SCRIPT
-// override (as home/.config/pier/setup.sh), and a generated
-// home/.config/pier/env with the session tokens. The bootstrap extracts the
-// two prefixes to the right places.
+// home/), the repo files named by .pier/include (relative paths kept, prefix
+// repo/), a PIER_SETUP_SCRIPT override (as home/.config/pier/setup.sh), and a
+// generated home/.config/pier/env with the session tokens. The bootstrap
+// extracts the two prefixes to the right places.
 func buildFilesTar(dst string, manifest []string, repoRoot string, env map[string]string, setupSrc string) error {
 	f, err := os.Create(dst)
 	if err != nil {
@@ -301,13 +300,6 @@ func buildFilesTar(dst string, manifest []string, repoRoot string, env map[strin
 			return err
 		}
 		if _, err := tw.Write(seed); err != nil {
-			return err
-		}
-	}
-
-	repoSetup := filepath.Join(repoRoot, ".pier", "setup.sh")
-	if fi, err := os.Stat(repoSetup); err == nil && fi.Mode().IsRegular() {
-		if err := addFile(repoSetup, "repo/.pier/setup.sh", 0o755); err != nil {
 			return err
 		}
 	}

--- a/internal/driver/payload/files.go
+++ b/internal/driver/payload/files.go
@@ -120,8 +120,8 @@ func portableMCP(servers map[string]json.RawMessage) map[string]json.RawMessage 
 	return out
 }
 
-// pierIncludeFiles lists the repo files (repo-relative) named by a repo-root
-// .pier-include — the ONLY loose-file channel: nothing untracked or ignored
+// pierIncludeFiles lists the repo files (repo-relative) named by .pier/include
+// — the ONLY loose-file channel: nothing untracked or ignored
 // ships without a line here (tracked content arrives via the fetch, dirty
 // edits to it via the patch). One path or glob per line (relative to the
 // root; * ? [] per segment, no **), # comments, a directory line carries its
@@ -132,7 +132,7 @@ func portableMCP(servers map[string]json.RawMessage) map[string]json.RawMessage 
 // distinction, and the tar extracts after checkout + patch, so listed content
 // wins. No file, or an empty one, means nothing extra travels.
 func pierIncludeFiles(repoRoot string) []string {
-	b, err := os.ReadFile(filepath.Join(repoRoot, ".pier-include"))
+	b, err := os.ReadFile(filepath.Join(repoRoot, ".pier", "include"))
 	if err != nil {
 		return nil
 	}
@@ -214,11 +214,10 @@ func envFilesNotCarried(repoRoot string, carried []string) []string {
 	return miss
 }
 
-// setupScriptOverride resolves PIER_SETUP_SCRIPT: the named
-// script travels in the tar and the bootstrap runs it instead of the repo's
-// ./.pier-setup.sh. Relative paths resolve against the repo root, ~ against
-// home. A set-but-missing path returns a warning, not an error — a typo'd
-// env var shouldn't brick creates, but it must not be silent either.
+// setupScriptOverride resolves PIER_SETUP_SCRIPT. Relative overrides resolve
+// against the repo root, ~ against home. A set-but-missing override warns and
+// falls back to the repo's .pier/setup.sh — a typo shouldn't brick creates,
+// but it must not be silent.
 func setupScriptOverride(repoRoot string) (path, warn string) {
 	v := os.Getenv("PIER_SETUP_SCRIPT")
 	if v == "" {
@@ -231,16 +230,17 @@ func setupScriptOverride(repoRoot string) (path, warn string) {
 		v = filepath.Join(repoRoot, v)
 	}
 	if fi, err := os.Stat(v); err != nil || !fi.Mode().IsRegular() {
-		return "", "PIER_SETUP_SCRIPT: " + v + " not found — running the repo's .pier-setup.sh (if any) instead"
+		return "", "PIER_SETUP_SCRIPT: " + v + " not found — running the repo's .pier/setup.sh (if any) instead"
 	}
 	return v, ""
 }
 
 // buildFilesTar packs, into one tar: manifest files/dirs under $HOME (prefix
-// home/), the repo files named by .pier-include (relative paths kept, prefix
-// repo/), the PIER_SETUP_SCRIPT override (as home/.config/pier/setup.sh),
-// and a generated home/.config/pier/env with the session tokens. The
-// bootstrap extracts the two prefixes to the right places.
+// home/), the repo files named by .pier/include plus the ignored
+// .pier/setup.sh (relative paths kept, prefix repo/), a PIER_SETUP_SCRIPT
+// override (as home/.config/pier/setup.sh), and a generated
+// home/.config/pier/env with the session tokens. The bootstrap extracts the
+// two prefixes to the right places.
 func buildFilesTar(dst string, manifest []string, repoRoot string, env map[string]string, setupSrc string) error {
 	f, err := os.Create(dst)
 	if err != nil {
@@ -305,6 +305,13 @@ func buildFilesTar(dst string, manifest []string, repoRoot string, env map[strin
 		}
 	}
 
+	repoSetup := filepath.Join(repoRoot, ".pier", "setup.sh")
+	if fi, err := os.Stat(repoSetup); err == nil && fi.Mode().IsRegular() {
+		if err := addFile(repoSetup, "repo/.pier/setup.sh", 0o755); err != nil {
+			return err
+		}
+	}
+
 	for _, rel := range pierIncludeFiles(repoRoot) {
 		p := filepath.Join(repoRoot, rel)
 		if fi, err := os.Stat(p); err == nil && fi.Mode().IsRegular() {
@@ -324,7 +331,8 @@ func buildFilesTar(dst string, manifest []string, repoRoot string, env map[strin
 	}
 
 	if setupSrc != "" {
-		// 0755 regardless of the source's mode: the bootstrap gates on -x.
+		// Normalize the override mode even though the bootstrap deliberately
+		// invokes it with bash and only gates on presence.
 		if err := addFile(setupSrc, "home/.config/pier/setup.sh", 0o755); err != nil {
 			return err
 		}

--- a/internal/driver/payload/git.go
+++ b/internal/driver/payload/git.go
@@ -160,7 +160,7 @@ func gitBundle(repo, sha, dst, ref string, thin bool) error {
 // adds, deletions, binary-safe — as one patch the bootstrap applies right
 // after checkout, so the session's working tree starts exactly as the
 // laptop's (staged edits arrive unstaged). Untracked files are
-// .pier-include's business. A clean tree writes nothing.
+// .pier/include's business. A clean tree writes nothing.
 func dirtyPatch(repoRoot, dst string) (bool, error) {
 	out, err := exec.Command("git", "-C", repoRoot, "diff", "--binary", "HEAD").Output()
 	if err != nil {

--- a/internal/driver/payload/payload.go
+++ b/internal/driver/payload/payload.go
@@ -1,10 +1,9 @@
 // Package payload assembles everything a new session VM receives: the
 // repo-transfer decision (github fetch, thin bundle, or full bundle), the
 // dirty-tracked patch, the files tar (secrets manifest + .pier/include extras
-// + the selected .pier/setup.sh + session env), the cloud-init user-data, and
-// the bootstrap script that puts it all in place. Cloud-agnostic by
-// construction — drivers launch, push, and run; nothing here knows which
-// cloud is on the other end.
+// + session env), the cloud-init user-data, and the bootstrap script that
+// puts it all in place. Cloud-agnostic by construction — drivers launch,
+// push, and run; nothing here knows which cloud is on the other end.
 package payload
 
 import (

--- a/internal/driver/payload/payload.go
+++ b/internal/driver/payload/payload.go
@@ -1,9 +1,10 @@
 // Package payload assembles everything a new session VM receives: the
 // repo-transfer decision (github fetch, thin bundle, or full bundle), the
-// dirty-tracked patch, the files tar (secrets manifest + .pier-include extras
-// + session env), the cloud-init user-data, and the bootstrap script that
-// puts it all in place. Cloud-agnostic by construction — drivers launch,
-// push, and run; nothing here knows which cloud is on the other end.
+// dirty-tracked patch, the files tar (secrets manifest + .pier/include extras
+// + the selected .pier/setup.sh + session env), the cloud-init user-data, and
+// the bootstrap script that puts it all in place. Cloud-agnostic by
+// construction — drivers launch, push, and run; nothing here knows which
+// cloud is on the other end.
 package payload
 
 import (
@@ -105,7 +106,7 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 		if len(miss) > 1 {
 			name += fmt.Sprintf(" +%d more", len(miss)-1)
 		}
-		progress("not carrying " + name + " — env files travel only when .pier-include lists them")
+		progress("not carrying " + name + " — env files travel only when .pier/include lists them")
 	}
 	supPath := filepath.Join(dir, "pier-supervisor")
 	if err := os.WriteFile(supPath, supervisor, 0o755); err != nil {

--- a/internal/driver/payload/payload_test.go
+++ b/internal/driver/payload/payload_test.go
@@ -161,8 +161,8 @@ func TestRenderBootstrapModes(t *testing.T) {
 		// shell variables must survive rendering escaped — they belong to the
 		// tmux window's bash, not to the bootstrap shell.
 		`echo running > ~/.pier-setup.status`,
-		// Runs on presence via bash: a committed 0644 .pier-setup.sh (git
-		// only carries +x when the author set it) must not skip silently.
+		// Runs on presence via bash: a 0644 .pier/setup.sh must not skip
+		// silently.
 		`if [ -f "$setup" ]; then`,
 		`bash $setup 2>&1`,
 		// The cloud-init wait must guard on binaries the stock image LACKS
@@ -178,8 +178,9 @@ func TestRenderBootstrapModes(t *testing.T) {
 		// The tmux server must start through sudo, which re-runs initgroups:
 		// the bootstrap's own login predates cloud-init's usermod -aG docker
 		// on stock images, and every window inherits groups from the server
-		// (docker.sock denied in .pier-setup.sh otherwise).
+		// (docker.sock denied in .pier/setup.sh otherwise).
 		`sudo -u agent tmux new-session -d -s main`,
+		`setup=./.pier/setup.sh`,
 	} {
 		if !strings.Contains(origin, want) {
 			t.Errorf("origin-mode bootstrap missing %q", want)
@@ -245,7 +246,7 @@ func TestRenderUserDataGuards(t *testing.T) {
 // Nothing loose ships by default — but the create warns about env files it
 // is NOT carrying (untracked or ignored, any depth), minus wholly-ignored
 // dirs (node_modules fixtures), tracked ones (they arrive with the fetch),
-// and whatever .pier-include already carries.
+// and whatever .pier/include already carries.
 func TestEnvFilesNotCarried(t *testing.T) {
 	root := t.TempDir()
 	git := func(args ...string) {
@@ -276,7 +277,7 @@ func TestEnvFilesNotCarried(t *testing.T) {
 	git("add", ".gitignore", "apps/api/.env.example")
 
 	if files := pierIncludeFiles(root); files != nil {
-		t.Errorf("no .pier-include must mean nothing loose ships, got %v", files)
+		t.Errorf("no .pier/include must mean nothing loose ships, got %v", files)
 	}
 	got := envFilesNotCarried(root, nil)
 	want := []string{".env", "apps/api/.env", "apps/api/.env.local"}
@@ -291,7 +292,7 @@ func TestEnvFilesNotCarried(t *testing.T) {
 }
 
 // Uncommitted work on tracked files — edits and staged adds — travels as one
-// patch; untracked files don't (that's .pier-include's channel). A clean
+// patch; untracked files don't (that's .pier/include's channel). A clean
 // tree writes no patch at all.
 func TestDirtyPatch(t *testing.T) {
 	root := t.TempDir()
@@ -339,7 +340,7 @@ func TestDirtyPatch(t *testing.T) {
 	}
 }
 
-// .pier-include is the only loose-file channel: lines are paths or globs,
+// .pier/include is the only loose-file channel: lines are paths or globs,
 // matched against the disk with no git-status distinction (the fixture isn't
 // even a git repo). Directory lines carry their whole subtree; escapes and
 // comments are dropped.
@@ -355,7 +356,10 @@ func TestPierInclude(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(root, ".pier-include"),
+	if err := os.MkdirAll(filepath.Join(root, ".pier"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".pier", "include"),
 		[]byte("# what travels\napps/*/.env*\nuploads/\nsecrets.txt\n../escape\n/etc/passwd\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +375,64 @@ func TestPierInclude(t *testing.T) {
 	want := []string{"apps/api/.env", "apps/api/.env.local", "apps/web/.env",
 		"secrets.txt", "uploads/fixtures/a.bin"}
 	if !slices.Equal(got, want) {
-		t.Errorf("with .pier-include = %v, want %v", got, want)
+		t.Errorf("with .pier/include = %v, want %v", got, want)
+	}
+}
+
+func TestFilesTarCarriesIgnoredSetupScript(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".pier")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	setup := filepath.Join(configDir, "setup.sh")
+	if err := os.WriteFile(setup, []byte("#!/bin/sh\necho ready\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PIER_SETUP_SCRIPT", "")
+	got, warn := setupScriptOverride(root)
+	if got != "" || warn != "" {
+		t.Fatalf("setupScriptOverride() = %q, %q; want no override or warning", got, warn)
+	}
+
+	dst := filepath.Join(t.TempDir(), "files.tar")
+	if err := buildFilesTar(dst, nil, root, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	found := false
+	tr := tar.NewReader(f)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header.Name == "repo/.pier/setup.sh" {
+			contents, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(contents) != "#!/bin/sh\necho ready\n" {
+				t.Fatalf("carried setup contents = %q", contents)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("ignored .pier/setup.sh was not carried in files tar")
+	}
+
+	t.Setenv("PIER_SETUP_SCRIPT", "missing.sh")
+	got, warn = setupScriptOverride(root)
+	if got != "" || !strings.Contains(warn, "not found") {
+		t.Fatalf("missing override = %q, %q; want repo fallback and warning", got, warn)
 	}
 }
 
@@ -398,7 +459,10 @@ func TestPierIncludeDereferencesDirectFileSymlinks(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(root, ".pier-include"),
+	if err := os.MkdirAll(filepath.Join(root, ".pier"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".pier", "include"),
 		[]byte("apps/*/.env\nbroken\nsource-dir\nuploads/\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -447,7 +511,10 @@ func TestPierIncludeDereferencesDirectFileSymlinks(t *testing.T) {
 // Docker Desktop bind-mounts unreadable to every container on the VM.
 func TestFilesTarWidensCarriedModes(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".pier-include"), []byte(".env\nrun.sh\n"), 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, ".pier"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".pier", "include"), []byte(".env\nrun.sh\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("K=v\n"), 0o600); err != nil {

--- a/internal/driver/payload/payload_test.go
+++ b/internal/driver/payload/payload_test.go
@@ -379,63 +379,6 @@ func TestPierInclude(t *testing.T) {
 	}
 }
 
-func TestFilesTarCarriesIgnoredSetupScript(t *testing.T) {
-	root := t.TempDir()
-	configDir := filepath.Join(root, ".pier")
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	setup := filepath.Join(configDir, "setup.sh")
-	if err := os.WriteFile(setup, []byte("#!/bin/sh\necho ready\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PIER_SETUP_SCRIPT", "")
-	got, warn := setupScriptOverride(root)
-	if got != "" || warn != "" {
-		t.Fatalf("setupScriptOverride() = %q, %q; want no override or warning", got, warn)
-	}
-
-	dst := filepath.Join(t.TempDir(), "files.tar")
-	if err := buildFilesTar(dst, nil, root, nil, ""); err != nil {
-		t.Fatal(err)
-	}
-	f, err := os.Open(dst)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close()
-	found := false
-	tr := tar.NewReader(f)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		if header.Name == "repo/.pier/setup.sh" {
-			contents, err := io.ReadAll(tr)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if string(contents) != "#!/bin/sh\necho ready\n" {
-				t.Fatalf("carried setup contents = %q", contents)
-			}
-			found = true
-		}
-	}
-	if !found {
-		t.Fatal("ignored .pier/setup.sh was not carried in files tar")
-	}
-
-	t.Setenv("PIER_SETUP_SCRIPT", "missing.sh")
-	got, warn = setupScriptOverride(root)
-	if got != "" || !strings.Contains(warn, "not found") {
-		t.Fatalf("missing override = %q, %q; want repo fallback and warning", got, warn)
-	}
-}
-
 func TestPierIncludeDereferencesDirectFileSymlinks(t *testing.T) {
 	root := t.TempDir()
 	sources := t.TempDir()

--- a/internal/driver/payload/scripts.go
+++ b/internal/driver/payload/scripts.go
@@ -109,7 +109,7 @@ set -euo pipefail
 # Stock image: harness install still running under cloud-init; wait it out.
 # Guard on binaries the stock image LACKS: Ubuntu ships git and tmux, so
 # guarding on those skipped the wait everywhere (the same trap the
-# user-data idempotency guards document) and .pier-setup.sh raced the
+# user-data idempotency guards document) and .pier/setup.sh raced the
 # node/docker/claude installs it depends on.
 command -v docker >/dev/null && command -v node >/dev/null && command -v claude >/dev/null || sudo cloud-init status --wait >/dev/null || true
 
@@ -176,33 +176,32 @@ fi
 # login: on a stock image cloud-init's "usermod -aG docker agent" lands after
 # this ssh session began, so a server started directly here would carry a
 # pre-docker group set for its whole life — and every window forks from the
-# server, so .pier-setup.sh and the user's shells all get docker.sock denied.
+# server, so .pier/setup.sh and the user's shells all get docker.sock denied.
 # sudo re-runs initgroups, picking up /etc/group as it stands after the
 # cloud-init wait above.
 tmux has-session -t main 2>/dev/null || sudo -u agent tmux new-session -d -s main -e "SSH_AUTH_SOCK=$HOME/.ssh/agent.sock" -c "$HOME/work/{{REPO}}"
-# Background setup, after checkout + patch + .pier-include extras are all in
-# place: the repo's .pier-setup.sh, unless a PIER_SETUP_SCRIPT override rode
-# the tar (outer double quotes expand $setup now, into the single-quoted
-# bash -c; \$ defers the rest to run time). The outcome must be impossible to
+# Background setup, after checkout + patch + .pier/include extras are all in
+# place: the ignored .pier/setup.sh rode the tar into the repo; a
+# PIER_SETUP_SCRIPT override rides into ~/.config/pier and takes precedence.
+# Outer double quotes expand $setup now, into the single-quoted bash -c; \$
+# defers the rest to run time. The outcome must be impossible to
 # miss — a failed setup used to vanish with its window: ~/.pier-setup.status
 # holds "running" then the exit code (the supervisor beacons it to ls/TUI),
 # the log's last line says done/FAILED, and a failed window renames to
 # setup-failed and stays open instead of closing. The rename targets its own
 # pane id: with a client attached, a bare rename-window can resolve "current
 # window" to the attached client's window and mislabel the user's shell.
-setup=./.pier-setup.sh
+setup=./.pier/setup.sh
 if [ -f "$HOME/.config/pier/setup.sh" ]; then setup="$HOME/.config/pier/setup.sh"; fi
-# Presence is the signal, not the exec bit: git only carries +x when the
-# author remembered chmod, and gating on -x skipped a committed 0644
-# .pier-setup.sh with no trace — the one silent failure setup promises not
-# to have. bash runs it either way.
+# Presence is the signal, not the exec bit: bash runs the script either way,
+# so a source file with mode 0644 must not skip silently.
 if [ -f "$setup" ]; then
   tmux new-window -d -t main -n setup "bash -c 'set -a; . ~/.config/pier/env 2>/dev/null; set +a; cd ~/work/{{REPO}} || exit 1; echo running > ~/.pier-setup.status; bash $setup 2>&1 | tee ~/.pier-setup.log; c=\${PIPESTATUS[0]}; echo \$c > ~/.pier-setup.status; if [ \$c -eq 0 ]; then echo \"pier setup: done\" >> ~/.pier-setup.log; else echo \"pier setup: FAILED (exit \$c)\" | tee -a ~/.pier-setup.log; tmux rename-window -t \$TMUX_PANE setup-failed; exec sleep infinity; fi'"
 fi
 
 # Attach gates on this marker: nobody lands in a half-set-up session. Written
 # after the repo checkout and tmux session exist; deliberately NOT after
-# .pier-setup.sh, which runs async in its tmux window.
+# .pier/setup.sh, which runs async in its tmux window.
 touch "$HOME/.pier-bootstrapped"
 
 rm -f /tmp/pier.bundle /tmp/pier-files.tar /tmp/pier-dirty.patch /tmp/pier-supervisor /tmp/pier-bootstrap.sh

--- a/internal/driver/payload/scripts.go
+++ b/internal/driver/payload/scripts.go
@@ -181,10 +181,10 @@ fi
 # cloud-init wait above.
 tmux has-session -t main 2>/dev/null || sudo -u agent tmux new-session -d -s main -e "SSH_AUTH_SOCK=$HOME/.ssh/agent.sock" -c "$HOME/work/{{REPO}}"
 # Background setup, after checkout + patch + .pier/include extras are all in
-# place: the ignored .pier/setup.sh rode the tar into the repo; a
-# PIER_SETUP_SCRIPT override rides into ~/.config/pier and takes precedence.
-# Outer double quotes expand $setup now, into the single-quoted bash -c; \$
-# defers the rest to run time. The outcome must be impossible to
+# place: the repo's .pier/setup.sh, unless a PIER_SETUP_SCRIPT override rode
+# the tar into ~/.config/pier. Outer double quotes expand $setup now, into the
+# single-quoted bash -c; \$ defers the rest to run time. The outcome must be
+# impossible to
 # miss — a failed setup used to vanish with its window: ~/.pier-setup.status
 # holds "running" then the exit code (the supervisor beacons it to ls/TUI),
 # the log's last line says done/FAILED, and a failed window renames to

--- a/skills/pier-onboard/SKILL.md
+++ b/skills/pier-onboard/SKILL.md
@@ -1,22 +1,24 @@
 ---
 name: pier-onboard
-description: Set up a repository for pier — inspect the project and write its .pier-setup.sh, .pier-include, and .pier-bake.sh so pier sessions boot ready to work. Use when asked to set up, onboard, or configure pier for a repo.
+description: Set up a repository for pier — inspect the project, ignore its local .pier directory, and write setup.sh, include, and bake.sh there so pier sessions boot ready to work. Use when asked to set up, onboard, or configure pier for a repo.
 ---
 
 # Onboard a repository to pier
 
 pier runs coding-agent sessions as micro-VMs on the user's own AWS account.
 When a session is created, the repo is checked out on the VM, uncommitted
-edits arrive as a patch, and three optional repo-root files control the rest:
+edits arrive as a patch, and three optional files in a repo-root `.pier/`
+directory control the rest:
 
 | File | When it runs / travels | What belongs in it |
 |---|---|---|
-| `.pier-bake.sh` | Once, during `pier bake`, on a throwaway instance that becomes the repo's AMI | **Toolchains** — language runtimes, package managers |
-| `.pier-setup.sh` | On every session's first boot, async, after the repo lands | **Repo state** — dependency install, services, migrations, seeds |
-| `.pier-include` | List read at create time; matching files ride to the VM | **Untracked/ignored files** dev needs — env files, local certs |
+| `.pier/bake.sh` | Once, during `pier bake`, on a throwaway instance that becomes the repo's AMI | **Toolchains** — language runtimes, package managers |
+| `.pier/setup.sh` | On every session's first boot, async, after the repo lands | **Repo state** — dependency install, services, migrations, seeds |
+| `.pier/include` | List read at create time; matching files ride to the VM | **Untracked/ignored files** dev needs — env files, local certs |
 
-Your job: inspect this repo, write the files that apply, and tell the user
-what to run next. All three are optional — write only what the repo needs.
+Your job: inspect this repo, add the local Pier directory to `.gitignore`,
+write the files that apply, and tell the user what to run next. All three
+files are optional — write only what the repo needs.
 
 ## Step 1 — inspect the repo
 
@@ -30,15 +32,30 @@ From that, determine:
    node 22 + npm, git, gh, make, docker (with compose and buildx), tmux,
    jq, curl, unzip, and headless Chromium (playwright). Do **not**
    reinstall these. Anything else the build needs — pnpm/yarn, python,
-   uv, rust, java — goes in `.pier-bake.sh`.
+   uv, rust, java — goes in `.pier/bake.sh`.
 2. **The dev-setup sequence** — the commands a human runs after a fresh
    clone (install deps, start services, migrate, seed). That's
-   `.pier-setup.sh`.
+   `.pier/setup.sh`.
 3. **Files git doesn't carry** that dev needs — usually `.env*`. That's
-   `.pier-include`. Nothing untracked or gitignored ships unless listed
+   `.pier/include`. Nothing untracked or gitignored ships unless listed
    here; pier prints which env files it is *not* carrying at create time.
 
-## Step 2 — write `.pier-bake.sh` (only if toolchains are needed)
+## Step 2 — prepare the local config directory
+
+Ensure the repository-root `.gitignore` contains this exact root-anchored
+entry, adding the file if it does not exist and preserving all existing
+rules:
+
+```gitignore
+/.pier/
+```
+
+Add the entry only once, then create `.pier/`. The `.gitignore` change is
+shared repository policy; the config files under `.pier/` stay local. Pier
+explicitly carries the selected setup script when it creates a session, so
+do not add `.pier/` to `.pier/include`.
+
+## Step 3 — write `.pier/bake.sh` (only if toolchains are needed)
 
 Runs as the `agent` user with passwordless sudo on the bake instance.
 **There is no repo checkout yet** — bake predates any session — so nothing
@@ -50,7 +67,7 @@ Example for a repo whose `package.json` pins `"packageManager": "pnpm@10.6.5"`:
 ```bash
 #!/usr/bin/env bash
 # pier bake hook: runs once on the bake instance (agent user, passwordless
-# sudo, NO repo checkout). Toolchains only; repo state goes in .pier-setup.sh.
+# sudo, NO repo checkout). Toolchains only; repo state goes in .pier/setup.sh.
 set -euo pipefail
 
 # corepack ships with node 22 but prompts on TTYs before downloading —
@@ -62,11 +79,11 @@ COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install -g pnpm@10.6.5
 
 For apt installs, use `sudo DEBIAN_FRONTEND=noninteractive apt-get install -y …`.
 
-## Step 3 — write `.pier-setup.sh`
+## Step 4 — write `.pier/setup.sh`
 
 Runs asynchronously in a `setup` tmux window on the session's first boot,
 with the repo root as cwd, after the checkout, dirty patch, and
-`.pier-include` files are all in place. The user's secrets env
+`.pier/include` files are all in place. The user's secrets env
 (`~/.config/pier/env`) is loaded. Output logs to `~/.pier-setup.log`; a
 nonzero exit shows as `(setup failed)` in `pier ls`, so **let failures
 fail** — start with `set -euo pipefail`, don't swallow errors.
@@ -91,7 +108,7 @@ where possible. A bare background process must fully detach —
 when the script ends and SIGHUPs its process group (`nohup` alone does not
 detach it).
 
-## Step 4 — write `.pier-include` (only if loose files are needed)
+## Step 5 — write `.pier/include` (only if loose files are needed)
 
 One path or glob per line, relative to the repo root. `*`, `?`, `[]` match
 within a path segment — **no `**`**. A directory line carries its whole
@@ -109,11 +126,12 @@ apps/*/.env.local
 Only list what a dev session genuinely needs — everything listed leaves
 the laptop for the VM.
 
-## Step 5 — finish
+## Step 6 — finish
 
-- These files are meant to be committed (they name paths, not secrets).
-  pier runs both scripts with bash, so the exec bit is optional.
-- Tell the user: if you wrote or changed `.pier-bake.sh`, run `pier bake`
+- The `.gitignore` update is meant to be committed. The `.pier/` files remain
+  local and ignored. Pier runs both scripts with bash, so the exec bit is
+  optional.
+- Tell the user: if you wrote or changed `.pier/bake.sh`, run `pier bake`
   in the repo (~8 min, once per hook change). Then create a session and
   watch `pier ls` — `(setup running)` should clear; if it shows
   `(setup failed)`, attach and read `~/.pier-setup.log`.

--- a/skills/pier-onboard/SKILL.md
+++ b/skills/pier-onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pier-onboard
-description: Set up a repository for pier — inspect the project, ignore its local .pier directory, and write setup.sh, include, and bake.sh there so pier sessions boot ready to work. Use when asked to set up, onboard, or configure pier for a repo.
+description: Set up a repository for pier — inspect the project, write its committed .pier configuration, and update .gitignore for loose local files so pier sessions boot ready to work. Use when asked to set up, onboard, or configure pier for a repo.
 ---
 
 # Onboard a repository to pier
@@ -16,8 +16,8 @@ directory control the rest:
 | `.pier/setup.sh` | On every session's first boot, async, after the repo lands | **Repo state** — dependency install, services, migrations, seeds |
 | `.pier/include` | List read at create time; matching files ride to the VM | **Untracked/ignored files** dev needs — env files, local certs |
 
-Your job: inspect this repo, add the local Pier directory to `.gitignore`,
-write the files that apply, and tell the user what to run next. All three
+Your job: inspect this repo, write the files that apply, protect loose local
+files through `.gitignore`, and tell the user what to run next. All three
 files are optional — write only what the repo needs.
 
 ## Step 1 — inspect the repo
@@ -40,22 +40,7 @@ From that, determine:
    `.pier/include`. Nothing untracked or gitignored ships unless listed
    here; pier prints which env files it is *not* carrying at create time.
 
-## Step 2 — prepare the local config directory
-
-Ensure the repository-root `.gitignore` contains this exact root-anchored
-entry, adding the file if it does not exist and preserving all existing
-rules:
-
-```gitignore
-/.pier/
-```
-
-Add the entry only once, then create `.pier/`. The `.gitignore` change is
-shared repository policy; the config files under `.pier/` stay local. Pier
-explicitly carries the selected setup script when it creates a session, so
-do not add `.pier/` to `.pier/include`.
-
-## Step 3 — write `.pier/bake.sh` (only if toolchains are needed)
+## Step 2 — write `.pier/bake.sh` (only if toolchains are needed)
 
 Runs as the `agent` user with passwordless sudo on the bake instance.
 **There is no repo checkout yet** — bake predates any session — so nothing
@@ -79,7 +64,7 @@ COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install -g pnpm@10.6.5
 
 For apt installs, use `sudo DEBIAN_FRONTEND=noninteractive apt-get install -y …`.
 
-## Step 4 — write `.pier/setup.sh`
+## Step 3 — write `.pier/setup.sh`
 
 Runs asynchronously in a `setup` tmux window on the session's first boot,
 with the repo root as cwd, after the checkout, dirty patch, and
@@ -108,7 +93,7 @@ where possible. A bare background process must fully detach —
 when the script ends and SIGHUPs its process group (`nohup` alone does not
 detach it).
 
-## Step 5 — write `.pier/include` (only if loose files are needed)
+## Step 4 — write `.pier/include` (only if loose files are needed)
 
 One path or glob per line, relative to the repo root. `*`, `?`, `[]` match
 within a path segment — **no `**`**. A directory line carries its whole
@@ -126,11 +111,16 @@ apps/*/.env.local
 Only list what a dev session genuinely needs — everything listed leaves
 the laptop for the VM.
 
-## Step 6 — finish
+For every untracked local file or path added here, ensure the repository-root
+`.gitignore` ignores it so it cannot be committed accidentally. Add only
+missing rules and preserve all existing content. **Never ignore `.pier/`**:
+the Pier config directory contains project configuration and is meant to be
+committed.
 
-- The `.gitignore` update is meant to be committed. The `.pier/` files remain
-  local and ignored. Pier runs both scripts with bash, so the exec bit is
-  optional.
+## Step 5 — finish
+
+- The `.pier/` files and any `.gitignore` updates are meant to be committed.
+  Pier runs both scripts with bash, so the exec bit is optional.
 - Tell the user: if you wrote or changed `.pier/bake.sh`, run `pier bake`
   in the repo (~8 min, once per hook change). Then create a session and
   watch `pier ls` — `(setup running)` should clear; if it shows


### PR DESCRIPTION
## What does this PR do and why?

Consolidates the three committed repository-specific Pier config files under one .pier/ directory: setup.sh, include, and bake.sh. Pier now reads the new paths throughout create, setup, and bake flows. The pier-onboard skill keeps .pier/ tracked while ensuring loose local files referenced by .pier/include, such as .env files, remain protected by .gitignore. User and architecture documentation now describe the consolidated layout.

## Related issue

None.

## Tests

- make test
- make build

## Checklist

- [x] gofmt produces no output and go vet passes
- [x] make build succeeds
- [x] Tests added or updated for behavior changes
- [x] Docs updated