### PR TITLE
ci(release): bump the homebrew tap formula automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: validate release tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "::error::release tag must match vX.Y or vX.Y.Z"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
@@ -26,7 +34,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: checkout homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: usepier/homebrew-tap
           # fine-grained PAT with contents read/write on the tap repo; the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,15 @@ jobs:
         run: |
           url="https://github.com/usepier/pier/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
           sha=$(curl -fsSL "$url" | sha256sum | cut -d' ' -f1)
+          escaped_url=$(printf '%s\n' "$url" | sed 's/[&|\\]/\\&/g')
           sed -i \
-            -e "s|^  url .*|  url \"${url}\"|" \
+            -e "s|^  url .*|  url \"${escaped_url}\"|" \
             -e "s|^  sha256 .*|  sha256 \"${sha}\"|" \
             homebrew-tap/Formula/pier.rb
           # a formula reformat that dodges the sed patterns must fail here,
           # not push a stale formula silently
-          grep -q "$sha" homebrew-tap/Formula/pier.rb
+          grep -Fqx -- "  url \"${url}\"" homebrew-tap/Formula/pier.rb
+          grep -Fqx -- "  sha256 \"${sha}\"" homebrew-tap/Formula/pier.rb
       - name: push the tap bump
         working-directory: homebrew-tap
         run: |
@@ -52,6 +54,6 @@ jobs:
           if git diff --quiet; then
             echo "formula already at ${GITHUB_REF_NAME}, nothing to push"
           else
-            git commit -am "pier ${GITHUB_REF_NAME#v}"
+            git commit -am "chore: bump pier ${GITHUB_REF_NAME#v}"
             git push
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,33 @@ jobs:
         run: gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: checkout homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: usepier/homebrew-tap
+          # fine-grained PAT with contents read/write on the tap repo; the
+          # default GITHUB_TOKEN cannot push across repositories
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+      - name: bump formula to the released tag
+        run: |
+          url="https://github.com/usepier/pier/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
+          sha=$(curl -fsSL "$url" | sha256sum | cut -d' ' -f1)
+          sed -i \
+            -e "s|^  url .*|  url \"${url}\"|" \
+            -e "s|^  sha256 .*|  sha256 \"${sha}\"|" \
+            homebrew-tap/Formula/pier.rb
+          # a formula reformat that dodges the sed patterns must fail here,
+          # not push a stale formula silently
+          grep -q "$sha" homebrew-tap/Formula/pier.rb
+      - name: push the tap bump
+        working-directory: homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "formula already at ${GITHUB_REF_NAME}, nothing to push"
+          else
+            git commit -am "pier ${GITHUB_REF_NAME#v}"
+            git push
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,11 +67,15 @@ are no prebuilt artifacts to manage.
 1. Make sure CI is green on main.
 2. Tag and push:
    `git tag -a vX.Y.Z -m "pier vX.Y.Z" && git push origin vX.Y.Z`.
-   The release workflow re-runs the checks and publishes the GitHub release.
-3. Bump the Homebrew formula in
-   [usepier/homebrew-tap](https://github.com/usepier/homebrew-tap):
-   point `url` at the new tag and update `sha256`
-   (`curl -sL <tarball-url> | shasum -a 256`).
+   The release workflow re-runs the checks, publishes the GitHub release,
+   and bumps the Homebrew formula in
+   [usepier/homebrew-tap](https://github.com/usepier/homebrew-tap) to the
+   new tag's tarball url and sha256.
+
+The tap push authenticates with the `HOMEBREW_TAP_TOKEN` repository secret,
+a fine-grained PAT with contents read/write on usepier/homebrew-tap (the
+default `GITHUB_TOKEN` cannot push across repositories). If it expires,
+mint a new one and update the secret.
 
 Versioning is semver. While pier is 0.x, breaking changes bump the minor
 version.


### PR DESCRIPTION
## Why

Releasing currently ends with a manual step: hand-editing `url` and `sha256` in [usepier/homebrew-tap](https://github.com/usepier/homebrew-tap)'s `Formula/pier.rb`. The source repo should own the whole release, so the tag push now carries the formula bump with it.

## What

After `gh release create` succeeds, the release workflow now:

1. checks out `usepier/homebrew-tap` into a subdirectory, authenticated with the new `HOMEBREW_TAP_TOKEN` secret (a fine-grained PAT with contents read/write on the tap repo — the default `GITHUB_TOKEN` can't push across repositories),
2. computes the sha256 of the tag's source tarball and rewrites the formula's `url` and `sha256` lines (version derives from the url), with a `grep` assert so a formula reformat that dodges the sed patterns fails the job loudly instead of silently pushing nothing,
3. commits as `github-actions[bot]` (`pier X.Y.Z`, brew's conventional message) and pushes — skipped cleanly when the formula is already at the tag, matching the workflow's existing re-run tolerance.

No new workflow, no `repository_dispatch`, no release process in the tap repo; the existing steps are untouched. CONTRIBUTING's release section now documents the automated bump and the token.

## Verified

- Reproduced the live formula's exact sha256 (`3fde12d1…`) using the workflow's URL shape and pipeline.
- Proved the sed patterns hit exactly the `url` and `sha256` lines of the current formula (the `head` line is untouched).
- `actionlint` and YAML parse pass on the workflow.

## Before merging

Create a fine-grained PAT (resource owner `usepier`, only `usepier/homebrew-tap`, Contents: read/write) and add it as the `HOMEBREW_TAP_TOKEN` actions secret on this repo — the tap steps fail at checkout without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)