### PR TITLE
test: add hermetic lifecycle coverage for the GCP driver (#11)

### DIFF
--- a/internal/driver/gcpgce/cli.go
+++ b/internal/driver/gcpgce/cli.go
@@ -11,6 +11,11 @@ import (
 	"time"
 )
 
+var (
+	execCommand        = exec.Command
+	execCommandContext = exec.CommandContext
+)
+
 // gcloud runs the gcloud CLI (the tool already requires it for the IAP
 // tunnel, so v1 has no SDK dependency) and returns trimmed stdout. --quiet
 // suppresses every confirmation prompt; the project is always explicit so
@@ -21,7 +26,7 @@ func (d *Driver) gcloud(ctx context.Context, args ...string) (string, error) {
 	if d.Project != "" {
 		full = append(full, "--project", d.Project)
 	}
-	cmd := exec.CommandContext(ctx, "gcloud", full...)
+	cmd := execCommandContext(ctx, "gcloud", full...)
 	var out, errb bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &out, &errb
 	if err := cmd.Run(); err != nil {
@@ -130,7 +135,7 @@ func (d *Driver) sshRun(ctx context.Context, id, script string) (string, error) 
 // the workspace fetch rides the laptop's ssh agent.
 func (d *Driver) sshRunOpts(ctx context.Context, id string, extra []string, script string) (string, error) {
 	args := append(append(d.sshOpts(id), extra...), "agent@"+id, script)
-	out, err := exec.CommandContext(ctx, "ssh", args...).CombinedOutput()
+	out, err := execCommandContext(ctx, "ssh", args...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("ssh %s: %s", id, strings.TrimSpace(string(out)))
 	}
@@ -142,7 +147,7 @@ func (d *Driver) sshRunOpts(ctx context.Context, id string, extra []string, scri
 // like a hang.
 func (d *Driver) sshStream(ctx context.Context, id, script string) error {
 	args := append(d.sshOpts(id), "agent@"+id, script)
-	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd := execCommandContext(ctx, "ssh", args...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	return cmd.Run()
 }
@@ -151,7 +156,7 @@ func (d *Driver) sshStream(ctx context.Context, id, script string) error {
 // pushes too small to warrant one.
 func (d *Driver) scpTo(ctx context.Context, id, local, remote string, extra ...string) error {
 	args := append(append(d.sshOpts(id), extra...), local, "agent@"+id+":"+remote)
-	cmd := exec.CommandContext(ctx, "scp", args...)
+	cmd := execCommandContext(ctx, "scp", args...)
 	// scp draws its progress meter only when stdout is a terminal — so big
 	// pushes (the repo bundle) show live progress interactively and stay
 	// silent when piped.
@@ -174,7 +179,7 @@ func (d *Driver) newKeypair(id string) (string, error) {
 	key := d.keyPath(id)
 	_ = os.Remove(key)
 	_ = os.Remove(key + ".pub")
-	out, err := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-C", "pier", "-f", key).CombinedOutput()
+	out, err := execCommand("ssh-keygen", "-t", "ed25519", "-N", "", "-C", "pier", "-f", key).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("ssh-keygen: %s", strings.TrimSpace(string(out)))
 	}

--- a/internal/driver/gcpgce/driver.go
+++ b/internal/driver/gcpgce/driver.go
@@ -328,7 +328,7 @@ func (d *Driver) Destroy(ctx context.Context, id string) error {
 	_ = os.Remove(d.keyPath(id) + ".pub")
 	// Drop the host key: a same-named recreate (same session name, same
 	// principal) would otherwise trip a known_hosts mismatch.
-	hk := exec.Command("ssh-keygen", "-R", id, "-f", d.StateDir+"/known_hosts")
+	hk := execCommand("ssh-keygen", "-R", id, "-f", d.StateDir+"/known_hosts")
 	hk.Stdout, hk.Stderr = nil, nil
 	_ = hk.Run()
 	return nil
@@ -353,7 +353,7 @@ func (d *Driver) AttachCommand(ctx context.Context, id string) (*exec.Cmd, error
 if ! infocmp "$TERM" >/dev/null 2>&1; then export TERM=xterm-256color; fi
 exec tmux new-session -A -s main`
 	args := append(d.sshOpts(id), "-t", "-o", "ForwardAgent=yes", "agent@"+id, remote)
-	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd := execCommandContext(ctx, "ssh", args...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd, nil
 }
@@ -372,7 +372,7 @@ func (d *Driver) MCPLoginCommand(ctx context.Context, id, server string, port in
 		server, port)
 	args := append(d.sshOpts(id),
 		"-t", "-L", fmt.Sprintf("%d:localhost:%d", port, port), "agent@"+id, remote)
-	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd := execCommandContext(ctx, "ssh", args...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd, nil
 }
@@ -386,7 +386,7 @@ func (d *Driver) PortForwardCommand(ctx context.Context, id string, pairs [][2]i
 		args = append(args, "-L", fmt.Sprintf("%d:localhost:%d", p[0], p[1]))
 	}
 	args = append(args, "-N", "agent@"+id)
-	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd := execCommandContext(ctx, "ssh", args...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd, nil
 }

--- a/internal/driver/gcpgce/driver_test.go
+++ b/internal/driver/gcpgce/driver_test.go
@@ -2,8 +2,15 @@ package gcpgce
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/usepier/pier/internal/driver"
 )
 
 // gcloud crashes print multi-paragraph "run gcloud feedback" boilerplate;
@@ -115,5 +122,338 @@ func TestMachinesCatalog(t *testing.T) {
 
 	if amd64Catalog[0].Type == arm64Catalog[0].Type {
 		t.Fatalf("catalogs for amd64 and arm64 should be separate")
+	}
+}
+
+// --- Hermetic Lifecycle Tests ---
+
+func fakeExecCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", name}
+	cs = append(cs, args...)
+	cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	return cmd
+}
+
+func fakeExecCommand(name string, args ...string) *exec.Cmd {
+	return fakeExecCommandContext(context.Background(), name, args...)
+}
+
+func init() {
+	// Set package variables for testing
+	execCommand = fakeExecCommand
+	execCommandContext = fakeExecCommandContext
+}
+
+type mockResponse struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+func setupTestDriver(t *testing.T, responses map[string]mockResponse) (*Driver, string) {
+	logFile := filepath.Join(t.TempDir(), "cmd.log")
+	t.Setenv("FAKE_CMD_LOG", logFile)
+
+	// Ensure gcloud auth list doesn't fail
+	if responses == nil {
+		responses = make(map[string]mockResponse)
+	}
+	responses["auth list"] = mockResponse{Stdout: "testuser@example.com\n"}
+
+	b, err := json.Marshal(responses)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapFile := filepath.Join(t.TempDir(), "gcloud_map.json")
+	os.WriteFile(mapFile, b, 0644)
+	t.Setenv("FAKE_GCLOUD_MAP", mapFile)
+
+	d := &Driver{
+		Project:     "test-project",
+		Zone:        "us-central1-a",
+		MachineType: "e2-medium",
+		DiskGiB:     40,
+		StateDir:    t.TempDir(),
+		SupervisorBin: func(arch string) ([]byte, error) {
+			return []byte("supervisor"), nil
+		},
+	}
+	return d, logFile
+}
+
+func readCmdLog(t *testing.T, logFile string) []string {
+	b, err := os.ReadFile(logFile)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	var cmds []string
+	for _, l := range lines {
+		cmds = append(cmds, strings.ReplaceAll(l, "\x00", " "))
+	}
+	return cmds
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	args := os.Args[3:]
+	cmd := args[0]
+
+	if logFile := os.Getenv("FAKE_CMD_LOG"); logFile != "" {
+		f, _ := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		fmt.Fprintf(f, "%s\n", strings.Join(args, "\x00"))
+		f.Close()
+	}
+
+	switch cmd {
+	case "gcloud":
+		if mapFile := os.Getenv("FAKE_GCLOUD_MAP"); mapFile != "" {
+			b, _ := os.ReadFile(mapFile)
+			var responses map[string]mockResponse
+			json.Unmarshal(b, &responses)
+
+			argsStr := strings.Join(args[1:], " ")
+			for prefix, res := range responses {
+				if strings.Contains(argsStr, prefix) {
+					if res.ExitCode != 0 {
+						os.Stderr.WriteString(res.Stderr)
+						os.Exit(res.ExitCode)
+					}
+					os.Stdout.WriteString(res.Stdout)
+					return
+				}
+			}
+		}
+	case "ssh-keygen":
+		if len(args) > 8 && args[1] == "-t" {
+			keyPath := args[8]
+			os.WriteFile(keyPath+".pub", []byte("fake-pub-key"), 0644)
+		}
+	case "ssh", "scp":
+		// succeed silently
+	}
+}
+
+func setupDummyRepo(t *testing.T) string {
+	dir := t.TempDir()
+	// Use the real os/exec to initialize a dummy repo so payload.Build succeeds.
+	exec.Command("git", "init", "-b", "main", dir).Run()
+	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "init")
+	cmd.Dir = dir
+	cmd.Run()
+	return dir
+}
+
+func TestList(t *testing.T) {
+	// A mix of states
+	listJSON := `[
+		{"name": "pier-s1-111111", "status": "PROVISIONING", "labels": {"pier-user": "testuser-example-com"}, "metadata": {"items": [{"key": "pier-user", "value": "testuser@example.com"}, {"key": "pier-session", "value": "s1"}]}},
+		{"name": "pier-s2-222222", "status": "RUNNING", "labels": {"pier-user": "testuser-example-com", "pier-ready": "1"}, "metadata": {"items": [{"key": "pier-user", "value": "testuser@example.com"}, {"key": "pier-session", "value": "s2"}]}},
+		{"name": "pier-s3-333333", "status": "RUNNING", "labels": {"pier-user": "testuser-example-com", "pier-deleting": "1"}, "metadata": {"items": [{"key": "pier-user", "value": "testuser@example.com"}, {"key": "pier-session", "value": "s3"}]}},
+		{"name": "pier-s4-444444", "status": "TERMINATED", "labels": {"pier-user": "testuser-example-com"}, "metadata": {"items": [{"key": "pier-user", "value": "testuser@example.com"}, {"key": "pier-session", "value": "s4"}]}}
+	]`
+
+	d, logFile := setupTestDriver(t, map[string]mockResponse{
+		"compute instances list": {Stdout: listJSON},
+	})
+
+	sessions, err := d.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmds := readCmdLog(t, logFile)
+	foundList := false
+	for _, c := range cmds {
+		if strings.Contains(c, "compute instances list") {
+			foundList = true
+			if !strings.Contains(c, "labels.pier-managed=1") || !strings.Contains(c, "labels.pier-user=testuser-example-com") {
+				t.Errorf("list filter missing expected labels: %s", c)
+			}
+		}
+	}
+	if !foundList {
+		t.Fatal("list command not found in log")
+	}
+
+	if len(sessions) != 4 {
+		t.Fatalf("expected 4 sessions, got %d", len(sessions))
+	}
+
+	var states []driver.State
+	for _, s := range sessions {
+		states = append(states, s.State)
+	}
+	// order is sorted by session Name; since we didn't populate all names, they sort by ID (fallback).
+	// s1 = creating, s2 = running, s3 = deleting, s4 = parked
+	if states[0] != driver.StateCreating {
+		t.Errorf("s1 should be creating, got %s", states[0])
+	}
+	if states[1] != driver.StateRunning {
+		t.Errorf("s2 should be running, got %s", states[1])
+	}
+	if states[2] != driver.StateDeleting {
+		t.Errorf("s3 should be deleting, got %s", states[2])
+	}
+	if states[3] != driver.StateParked {
+		t.Errorf("s4 should be parked, got %s", states[3])
+	}
+}
+
+func TestCreate(t *testing.T) {
+	d, logFile := setupTestDriver(t, map[string]mockResponse{
+		"compute instances create":     {Stdout: "pier-my-session-abcdef"},
+		"compute instances add-labels": {Stdout: ""}, // for ready label
+	})
+
+	repo := setupDummyRepo(t)
+	spec := driver.CreateSpec{
+		Name:   "my-session",
+		Repo:   repo,
+		Branch: "main",
+	}
+
+	sess, err := d.Create(context.Background(), spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sess.State != driver.StateRunning {
+		t.Errorf("expected running state, got %s", sess.State)
+	}
+
+	cmds := readCmdLog(t, logFile)
+	foundCreate := false
+	foundAddLabels := false
+	for _, c := range cmds {
+		if strings.Contains(c, "compute instances create") {
+			foundCreate = true
+			if !strings.Contains(c, "--no-service-account") || !strings.Contains(c, "--no-scopes") {
+				t.Errorf("create missing secure defaults: %s", c)
+			}
+			if !strings.Contains(c, "--labels pier-managed=1,pier-user=testuser-example-com") {
+				t.Errorf("create missing labels: %s", c)
+			}
+		}
+		if strings.Contains(c, "add-labels") && strings.Contains(c, "pier-ready=1") {
+			foundAddLabels = true
+		}
+	}
+	if !foundCreate {
+		t.Error("create command not run")
+	}
+	if !foundAddLabels {
+		t.Error("ready label not added")
+	}
+}
+
+func TestCreateFailureQuota(t *testing.T) {
+	d, _ := setupTestDriver(t, map[string]mockResponse{
+		"compute instances create": {Stderr: "ERROR: ... QUOTA_EXCEEDED", ExitCode: 1},
+	})
+
+	repo := setupDummyRepo(t)
+	_, err := d.Create(context.Background(), driver.CreateSpec{
+		Name:   "fail-session",
+		Repo:   repo,
+		Branch: "main",
+	})
+	if err == nil || !strings.Contains(err.Error(), "CPU quota exceeded") {
+		t.Fatalf("expected quota error, got %v", err)
+	}
+}
+
+func TestCreateFailureCleanup(t *testing.T) {
+	d, logFile := setupTestDriver(t, map[string]mockResponse{
+		"compute instances create":     {Stdout: "pier-fail-session-1234"},
+		"compute instances add-labels": {Stderr: "Simulated failure adding ready label", ExitCode: 1},
+		"compute instances delete":     {Stdout: ""},
+	})
+
+	repo := setupDummyRepo(t)
+	_, err := d.Create(context.Background(), driver.CreateSpec{
+		Name:   "fail-session",
+		Repo:   repo,
+		Branch: "main",
+	})
+	if err == nil {
+		t.Fatal("expected create to fail")
+	}
+
+	cmds := readCmdLog(t, logFile)
+	foundDelete := false
+	for _, c := range cmds {
+		if strings.Contains(c, "compute instances delete") {
+			foundDelete = true
+		}
+	}
+	if !foundDelete {
+		t.Errorf("expected cleanup (delete) after create failure, log: %v", cmds)
+	}
+}
+
+func TestLifecycle(t *testing.T) {
+	d, logFile := setupTestDriver(t, map[string]mockResponse{
+		"compute instances stop":             {Stdout: ""},
+		"compute instances start":            {Stdout: ""},
+		"compute instances delete":           {Stdout: ""},
+		"compute instances describe":         {Stdout: "RUNNING e2-medium"},
+		"compute instances set-machine-type": {Stdout: ""},
+	})
+
+	id := "pier-session-123"
+
+	// Park
+	if err := d.Park(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume
+	if err := d.Resume(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resize (from e2-medium to e2-standard-4)
+	if err := d.Resize(context.Background(), id, "e2-standard-4"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cross-arch resize (should fail early)
+	err := d.Resize(context.Background(), id, "t2a-standard-2")
+	if err == nil || !strings.Contains(err.Error(), "cannot resize across architectures") {
+		t.Fatalf("expected cross-arch error, got %v", err)
+	}
+
+	// Destroy
+	if err := d.Destroy(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+
+	cmds := readCmdLog(t, logFile)
+	actions := strings.Join(cmds, "\n")
+
+	if !strings.Contains(actions, "instances stop "+id+" --zone "+d.Zone+" --async") {
+		t.Errorf("park missing --async stop, got: %s", actions)
+	}
+
+	// Resize should have stopped, set-machine-type, and started
+	if !strings.Contains(actions, "set-machine-type "+id+" --zone "+d.Zone+" --machine-type e2-standard-4") {
+		t.Errorf("resize missing set-machine-type, got: %s", actions)
+	}
+
+	// Destroy should add deleting label before deleting
+	if !strings.Contains(actions, "add-labels "+id+" --zone "+d.Zone+" --labels pier-deleting=1") {
+		t.Errorf("destroy missing deleting label, got: %s", actions)
+	}
+	if !strings.Contains(actions, "instances delete "+id+" --zone "+d.Zone) {
+		t.Errorf("destroy missing delete, got: %s", actions)
 	}
 }

--- a/internal/driver/gcpgce/driver_test.go
+++ b/internal/driver/gcpgce/driver_test.go
@@ -246,6 +246,12 @@ func setupDummyRepo(t *testing.T) string {
 	dir := t.TempDir()
 	// Use the real os/exec to initialize a dummy repo so payload.Build succeeds.
 	exec.Command("git", "init", "-b", "main", dir).Run()
+	configName := exec.Command("git", "config", "user.name", "Test User")
+	configName.Dir = dir
+	configName.Run()
+	configEmail := exec.Command("git", "config", "user.email", "test@example.com")
+	configEmail.Dir = dir
+	configEmail.Run()
 	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "init")
 	cmd.Dir = dir
 	cmd.Run()

--- a/internal/driver/gcpgce/setup.go
+++ b/internal/driver/gcpgce/setup.go
@@ -133,7 +133,7 @@ func (d *Driver) Doctor(ctx context.Context) []driver.Check {
 	switch {
 	case payload.GitHubToken() != "":
 		gh.Detail = "token found — private-repo fast fetch + push from sessions"
-	case exec.Command("ssh-add", "-l").Run() == nil:
+	case execCommand("ssh-add", "-l").Run() == nil:
 		gh.Detail = "ssh agent only — fast fetch relays it; pushes work while attached (`gh auth login` for detached pushes)"
 	default:
 		gh.OK = false


### PR DESCRIPTION
## What does this PR do and why?

This PR introduces hermetic testing for the `gcpgce` driver by implementing the `TestHelperProcess` pattern to mock the `gcloud` and `ssh` CLI boundaries. This allows us to strictly verify list filtering, owner verification, state mapping, secure create arguments, quota parsing, and the full lifecycle (Park, Resume, Resize, Destroy) without requiring a real Google Cloud account or network access. 

This brings the `gcpgce` package statement coverage from ~10.9% to 48.8%.

## Related issue

Closes #11

## Tests

Implemented a fake command runner via package-level `execCommand` variables and added table-driven lifecycle tests.

Local test output:
```text
$ go test -v ./internal/driver/gcpgce/...
...
=== RUN   TestList
--- PASS: TestList (0.66s)
=== RUN   TestCreate
--- PASS: TestCreate (0.67s)
=== RUN   TestCreateFailureQuota
--- PASS: TestCreateFailureQuota (0.17s)
=== RUN   TestCreateFailureCleanup
--- PASS: TestCreateFailureCleanup (0.70s)
=== RUN   TestLifecycle
--- PASS: TestLifecycle (0.17s)
PASS
ok      [github.com/usepier/pier/internal/driver/gcpgce](https://github.com/usepier/pier/internal/driver/gcpgce)  3.753s
coverage: 48.8% of statements

## Checklist

- [ ] `gofmt -l .` produces no output and `go vet ./...` passes
- [ ] `make build` succeeds (if this touches supervisor/session code)
- [ ] Tests added or updated for behavior changes
- [ ] Docs updated if applicable
