### PR TITLE
feat(skills): install the bundled pier-onboard skill for claude and codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,14 +284,16 @@ COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install -g pnpm@10.6.5
 
 ## The pier-onboard skill
 
-Don't write those files by hand. This repo ships
+Don't write those files by hand. pier ships
 [`skills/pier-onboard`](skills/pier-onboard/SKILL.md), a skill that teaches
 a coding agent to inspect your repo, write all three files with the right
 boundaries, and keep loose local files protected by `.gitignore`.
 
-```
-cp -r pier/skills/pier-onboard ~/.claude/skills/    # or your repo's .claude/skills/
-```
+`pier setup` offers it at the end, one confirm per agent on the machine —
+Claude Code (`~/.claude/skills`) and Codex (`~/.codex/skills`) read the
+same skill format — and `pier skills` runs the same install without
+questions, e.g. to refresh after a pier upgrade. To pin it to one repo
+instead, copy it into that repo's `.claude/skills/`.
 
 Then ask your agent to "set this repo up for pier".
 

--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -71,6 +71,8 @@ const usage = `usage:
   pier resize <session> <type>  grow/shrink the VM (running: ~1-2 min park+resume; same arch only)
   pier setup                first-run wizard (creates cloud groundwork)
       --print-admin           print the admin-runnable setup commands instead
+  pier skills               install/refresh the bundled agent skills
+                            (~/.claude/skills + ~/.codex/skills)
   pier doctor               environment + account checks
   pier bake                 prebake this repo's session image (~1-2 min creates)
   pier teardown             remove all pier groundwork from the account
@@ -104,6 +106,8 @@ func main() {
 		cmdResize(args[1:])
 	case "setup":
 		cmdSetup(args[1:])
+	case "skills":
+		cmdSkills()
 	case "doctor":
 		cmdDoctor()
 	case "bake":
@@ -822,12 +826,31 @@ func cmdResize(args []string) {
 	fmt.Println(ui.OK.Render(s.Name + " is now a " + itype))
 }
 
-// --- setup / doctor / bake / teardown ---------------------------------------------
+// --- setup / skills / doctor / bake / teardown ------------------------------------
 
 func cmdSetup(args []string) {
 	printAdmin := len(args) > 0 && args[0] == "--print-admin"
 	if err := wizard.Run(newDriver, printAdmin); err != nil {
 		fatal(err)
+	}
+}
+
+// cmdSkills is the standalone version of the wizard's skills step, minus
+// the questions — running the command is the confirmation, so it stays
+// scriptable. Refreshes the bundled skills for every agent on the machine,
+// e.g. after a pier upgrade. Idempotent; a no-op prints as such.
+func cmdSkills() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fatal(err)
+	}
+	agents := wizard.AgentDirs(home)
+	if len(agents) == 0 {
+		fmt.Println(ui.Dim.Render("  no agent config found (~/.claude or ~/.codex) — nothing to install into"))
+		return
+	}
+	for _, n := range wizard.InstallSkills(home, agents) {
+		fmt.Println(n)
 	}
 }
 

--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -849,8 +849,12 @@ func cmdSkills() {
 		fmt.Println(ui.Dim.Render("  no agent config found (~/.claude or ~/.codex) — nothing to install into"))
 		return
 	}
-	for _, n := range wizard.InstallSkills(home, agents) {
+	notes, err := wizard.InstallSkills(home, agents)
+	for _, n := range notes {
 		fmt.Println(n)
+	}
+	if err != nil {
+		fatal(err)
 	}
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -342,8 +342,8 @@ written back. Sources (wizard-detected, confirmed into the manifest):
   Directly matched file symlinks carry their target contents under the link's
   repo-relative path. Tracked content arrives with the fetch, dirty edits to
   it via the patch.
-- `~/.codex/` (auth.json, config.toml)
-- `~/.claude/` settings, `CLAUDE.md`, agents
+- `~/.codex/` (auth.json, config.toml, skills)
+- `~/.claude/` settings, `CLAUDE.md`, agents, skills
 - a GitHub credential for git push/PRs and private-repo fetch: `gh auth
   token` if gh is logged in, else the laptop's https git credential
   (`git credential fill`), else the ssh agent relayed via forwarding (fetch
@@ -375,7 +375,7 @@ written back. Sources (wizard-detected, confirmed into the manifest):
 
 ## 9. Setup wizard
 
-`pier setup` — plain stdin prompts (no TUI form), four phases, under 3
+`pier setup` — plain stdin prompts (no TUI form), five phases, under 3
 minutes:
 
 1. **Detect** — CLIs, profiles/projects, plugin, gh, harness configs; all
@@ -391,6 +391,13 @@ minutes:
    IAM rights. `pier teardown` reverses it.
 4. **Doctor** — quota headroom, connectivity, plugin; writes
    `~/.config/pier/config.toml`; prints `cd <repo> && pier <branch>`.
+5. **Skills** — one confirm per detected agent (claude, codex — same
+   SKILL.md format), then the bundled pier-onboard skill (embedded in the
+   binary) is installed/refreshed under `~/.<agent>/skills`. A dir
+   confirmed here postdates manifest detection, so it's appended to the
+   session manifest — only when the manifest was accepted at all. Runs
+   before the bake offer so no question hides behind the build.
+   `pier skills` is the same install standalone, no questions.
 
 Second dev on a prepared account: detect finds groundwork (`Existed`),
 creates nothing, done in ~90s.
@@ -420,6 +427,7 @@ pier rm <match>         destroy (instance + disk)
 pier keep <match>       disable auto-park for a session
 pier resize <match> <type>  change VM size (running: park→modify→resume; same arch)
 pier setup              wizard (--print-admin for the no-IAM-rights path)
+pier skills             install/refresh the bundled agent skills standalone
 pier bake               build/refresh the prebaked image
 pier doctor             checks
 pier teardown           remove account groundwork

--- a/internal/wizard/skills.go
+++ b/internal/wizard/skills.go
@@ -33,13 +33,14 @@ func AgentDirs(home string) []string {
 // user skills directory. Claude Code and Codex read the same SKILL.md
 // layout, so one tree serves both. Existing copies are refreshed in place,
 // so a pier upgrade propagates skill fixes. Runs from the wizard's skills
-// step and standalone as `pier skills`; returns print-ready progress lines.
-func InstallSkills(home string, agents []string) []string {
+// step and standalone as `pier skills`; returns print-ready progress lines
+// and any installation error.
+func InstallSkills(home string, agents []string) ([]string, error) {
 	var notes []string
 	for _, agent := range agents {
 		switch changed, err := syncSkills(filepath.Join(home, agent, "skills")); {
 		case err != nil:
-			notes = append(notes, "  "+ui.Mark(false)+" pier-onboard skill: "+err.Error())
+			return notes, fmt.Errorf("install pier-onboard skill in ~/%s/skills: %w", agent, err)
 		case changed:
 			notes = append(notes, "  "+ui.OK.Render("+")+" installed the pier-onboard skill "+
 				ui.Dim.Render("~/"+agent+"/skills — ask your agent to \"set this repo up for pier\""))
@@ -47,7 +48,7 @@ func InstallSkills(home string, agents []string) []string {
 			notes = append(notes, ui.Dim.Render("  = pier-onboard skill up to date in ~/"+agent+"/skills"))
 		}
 	}
-	return notes
+	return notes, nil
 }
 
 // offerSkills is the wizard's skills step: one confirm per detected agent,
@@ -72,8 +73,12 @@ func offerSkills(in *bufio.Reader, cfg *config.Config, home string) error {
 		fmt.Println(ui.Dim.Render("  (skipped — `pier skills` installs them anytime)"))
 		return nil
 	}
-	for _, n := range InstallSkills(home, chosen) {
+	notes, err := InstallSkills(home, chosen)
+	for _, n := range notes {
 		fmt.Println(n)
+	}
+	if err != nil {
+		return err
 	}
 	saved := false
 	for _, agent := range chosen {
@@ -93,9 +98,62 @@ func offerSkills(in *bufio.Reader, cfg *config.Config, home string) error {
 	return nil
 }
 
-// syncSkills writes every embedded skill file under dst, skipping files
-// already at the embedded content, and reports whether anything was written.
+// syncSkills makes each bundled skill subtree match the embedded copy while
+// leaving sibling, user-managed skills alone. It reports whether anything was
+// written or removed.
 func syncSkills(dst string) (changed bool, err error) {
+	expected := make(map[string]bool)
+	var roots []string
+	err = fs.WalkDir(skills.FS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		expected[path] = d.IsDir()
+		if path != "." && !strings.Contains(path, "/") {
+			roots = append(roots, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	// Remove paths no longer present in the bundle, plus file/directory type
+	// conflicts that would prevent the new copy from being written. Restrict
+	// reconciliation to embedded top-level roots so other installed skills are
+	// never touched.
+	for _, root := range roots {
+		rootPath := filepath.Join(dst, filepath.FromSlash(root))
+		if _, err := os.Lstat(rootPath); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return changed, err
+		}
+		if err := filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(dst, path)
+			if err != nil {
+				return err
+			}
+			wantDir, ok := expected[filepath.ToSlash(rel)]
+			if ok && wantDir == d.IsDir() {
+				return nil
+			}
+			if err := os.RemoveAll(path); err != nil {
+				return err
+			}
+			changed = true
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}); err != nil {
+			return changed, err
+		}
+	}
+
 	err = fs.WalkDir(skills.FS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err

--- a/internal/wizard/skills.go
+++ b/internal/wizard/skills.go
@@ -73,15 +73,16 @@ func offerSkills(in *bufio.Reader, cfg *config.Config, home string) error {
 		fmt.Println(ui.Dim.Render("  (skipped — `pier skills` installs them anytime)"))
 		return nil
 	}
-	notes, err := InstallSkills(home, chosen)
-	for _, n := range notes {
-		fmt.Println(n)
-	}
-	if err != nil {
-		return err
-	}
 	saved := false
 	for _, agent := range chosen {
+		notes, err := InstallSkills(home, []string{agent})
+		for _, n := range notes {
+			fmt.Println(n)
+		}
+		if err != nil {
+			return err
+		}
+
 		entry := agent + "/skills"
 		if len(cfg.Secrets.Manifest) > 0 && !slices.Contains(cfg.Secrets.Manifest, entry) {
 			cfg.Secrets.Manifest = append(cfg.Secrets.Manifest, entry)
@@ -98,19 +99,22 @@ func offerSkills(in *bufio.Reader, cfg *config.Config, home string) error {
 	return nil
 }
 
-// syncSkills makes each bundled skill subtree match the embedded copy while
-// leaving sibling, user-managed skills alone. It reports whether anything was
-// written or removed.
+const bundledSkillsIndex = ".pier-bundled-files"
+
+// syncSkills refreshes every embedded file and removes paths that an earlier
+// bundle owned but the current bundle no longer contains. The ownership index
+// leaves untracked, user-created files alone, including additions within a
+// bundled skill directory. It reports whether anything was written or removed.
 func syncSkills(dst string) (changed bool, err error) {
-	expected := make(map[string]bool)
-	var roots []string
+	current := make(map[string]struct{})
+	var currentFiles []string
 	err = fs.WalkDir(skills.FS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		expected[path] = d.IsDir()
-		if path != "." && !strings.Contains(path, "/") {
-			roots = append(roots, path)
+		if !d.IsDir() {
+			current[path] = struct{}{}
+			currentFiles = append(currentFiles, path)
 		}
 		return nil
 	})
@@ -118,38 +122,17 @@ func syncSkills(dst string) (changed bool, err error) {
 		return false, err
 	}
 
-	// Remove paths no longer present in the bundle, plus file/directory type
-	// conflicts that would prevent the new copy from being written. Restrict
-	// reconciliation to embedded top-level roots so other installed skills are
-	// never touched.
-	for _, root := range roots {
-		rootPath := filepath.Join(dst, filepath.FromSlash(root))
-		if _, err := os.Lstat(rootPath); os.IsNotExist(err) {
+	previousFiles, err := readBundledSkillsIndex(dst)
+	if err != nil {
+		return false, err
+	}
+	for _, path := range previousFiles {
+		if _, stillBundled := current[path]; stillBundled {
 			continue
-		} else if err != nil {
-			return changed, err
 		}
-		if err := filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			rel, err := filepath.Rel(dst, path)
-			if err != nil {
-				return err
-			}
-			wantDir, ok := expected[filepath.ToSlash(rel)]
-			if ok && wantDir == d.IsDir() {
-				return nil
-			}
-			if err := os.RemoveAll(path); err != nil {
-				return err
-			}
-			changed = true
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}); err != nil {
+		removed, err := removeBundledSkillFile(dst, path)
+		changed = changed || removed
+		if err != nil {
 			return changed, err
 		}
 	}
@@ -175,5 +158,84 @@ func syncSkills(dst string) (changed bool, err error) {
 		changed = true
 		return nil
 	})
-	return changed, err
+	if err != nil {
+		return changed, err
+	}
+
+	index := []byte(strings.Join(currentFiles, "\n") + "\n")
+	indexPath := filepath.Join(dst, bundledSkillsIndex)
+	if have, err := os.ReadFile(indexPath); err == nil && bytes.Equal(have, index) {
+		return changed, nil
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return changed, err
+	}
+	if err := os.WriteFile(indexPath, index, 0o644); err != nil {
+		return changed, err
+	}
+	return true, nil
+}
+
+func readBundledSkillsIndex(dst string) ([]string, error) {
+	b, err := os.ReadFile(filepath.Join(dst, bundledSkillsIndex))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for _, path := range strings.Split(string(b), "\n") {
+		if path == "" {
+			continue
+		}
+		if path == "." || path == bundledSkillsIndex || !fs.ValidPath(path) || strings.Contains(path, `\`) {
+			return nil, fmt.Errorf("invalid path %q in %s", path, bundledSkillsIndex)
+		}
+		paths = append(paths, path)
+	}
+	return paths, nil
+}
+
+// removeBundledSkillFile removes one path claimed by the previous ownership
+// index, then prunes only empty parent directories. A directory where the
+// index promised a file is left intact because it may contain user data.
+func removeBundledSkillFile(dst, path string) (bool, error) {
+	target := filepath.Join(dst, filepath.FromSlash(path))
+	info, err := os.Lstat(target)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.IsDir() {
+		return false, fmt.Errorf("remove obsolete bundled file %s: path is now a directory", target)
+	}
+	if err := os.Remove(target); err != nil {
+		return false, err
+	}
+	return true, pruneEmptySkillDirs(filepath.Dir(target), dst)
+}
+
+func pruneEmptySkillDirs(dir, stop string) error {
+	for dir != stop {
+		entries, err := os.ReadDir(dir)
+		if os.IsNotExist(err) {
+			dir = filepath.Dir(dir)
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if len(entries) != 0 {
+			return nil
+		}
+		if err := os.Remove(dir); err != nil {
+			return err
+		}
+		dir = filepath.Dir(dir)
+	}
+	return nil
 }

--- a/internal/wizard/skills.go
+++ b/internal/wizard/skills.go
@@ -1,0 +1,121 @@
+package wizard
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/usepier/pier/internal/config"
+	"github.com/usepier/pier/internal/ui"
+	"github.com/usepier/pier/skills"
+)
+
+// AgentDirs reports which agent config dirs exist under home (".claude",
+// ".codex") — the agents this machine actually runs. pier never conjures
+// one that isn't there.
+func AgentDirs(home string) []string {
+	var found []string
+	for _, agent := range []string{".claude", ".codex"} {
+		if _, err := os.Stat(filepath.Join(home, agent)); err == nil {
+			found = append(found, agent)
+		}
+	}
+	return found
+}
+
+// InstallSkills lays the bundled skills (skills.FS — notably pier-onboard,
+// how an agent learns to write a repo's .pier files) into each named agent's
+// user skills directory. Claude Code and Codex read the same SKILL.md
+// layout, so one tree serves both. Existing copies are refreshed in place,
+// so a pier upgrade propagates skill fixes. Runs from the wizard's skills
+// step and standalone as `pier skills`; returns print-ready progress lines.
+func InstallSkills(home string, agents []string) []string {
+	var notes []string
+	for _, agent := range agents {
+		switch changed, err := syncSkills(filepath.Join(home, agent, "skills")); {
+		case err != nil:
+			notes = append(notes, "  "+ui.Mark(false)+" pier-onboard skill: "+err.Error())
+		case changed:
+			notes = append(notes, "  "+ui.OK.Render("+")+" installed the pier-onboard skill "+
+				ui.Dim.Render("~/"+agent+"/skills — ask your agent to \"set this repo up for pier\""))
+		default:
+			notes = append(notes, ui.Dim.Render("  = pier-onboard skill up to date in ~/"+agent+"/skills"))
+		}
+	}
+	return notes
+}
+
+// offerSkills is the wizard's skills step: one confirm per detected agent,
+// then install. A skills dir confirmed here may postdate manifest detection
+// (first run), so it's appended to the session manifest and the config
+// re-saved — but only when the user opted into copying agent config at all
+// (an emptied manifest means they said no).
+func offerSkills(in *bufio.Reader, cfg *config.Config, home string) error {
+	agents := AgentDirs(home)
+	if len(agents) == 0 {
+		return nil
+	}
+	fmt.Println("\n " + ui.Accent.Render("agent skills") +
+		ui.Dim.Render("  pier-onboard teaches an agent to set a repo up for pier"))
+	var chosen []string
+	for _, agent := range agents {
+		if yes(in, "install/refresh for "+strings.TrimPrefix(agent, ".")+" (~/"+agent+"/skills)?", true) {
+			chosen = append(chosen, agent)
+		}
+	}
+	if len(chosen) == 0 {
+		fmt.Println(ui.Dim.Render("  (skipped — `pier skills` installs them anytime)"))
+		return nil
+	}
+	for _, n := range InstallSkills(home, chosen) {
+		fmt.Println(n)
+	}
+	saved := false
+	for _, agent := range chosen {
+		entry := agent + "/skills"
+		if len(cfg.Secrets.Manifest) > 0 && !slices.Contains(cfg.Secrets.Manifest, entry) {
+			cfg.Secrets.Manifest = append(cfg.Secrets.Manifest, entry)
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+			saved = true
+			fmt.Println(ui.Dim.Render("    + ~/" + entry + " added to the session manifest"))
+		}
+	}
+	if saved {
+		fmt.Println(ui.Dim.Render("  the skill travels into sessions with the rest of the agent config"))
+	}
+	return nil
+}
+
+// syncSkills writes every embedded skill file under dst, skipping files
+// already at the embedded content, and reports whether anything was written.
+func syncSkills(dst string) (changed bool, err error) {
+	err = fs.WalkDir(skills.FS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		want, err := fs.ReadFile(skills.FS, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, filepath.FromSlash(path))
+		if have, err := os.ReadFile(target); err == nil && bytes.Equal(have, want) {
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, want, 0o644); err != nil {
+			return err
+		}
+		changed = true
+		return nil
+	})
+	return changed, err
+}

--- a/internal/wizard/skills.go
+++ b/internal/wizard/skills.go
@@ -146,16 +146,11 @@ func syncSkills(dst string) (changed bool, err error) {
 			return err
 		}
 		target := filepath.Join(dst, filepath.FromSlash(path))
-		if have, err := os.ReadFile(target); err == nil && bytes.Equal(have, want) {
-			return nil
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		wrote, err := writeBundledSkillFile(dst, target, want)
+		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(target, want, 0o644); err != nil {
-			return err
-		}
-		changed = true
+		changed = changed || wrote
 		return nil
 	})
 	if err != nil {
@@ -164,23 +159,29 @@ func syncSkills(dst string) (changed bool, err error) {
 
 	index := []byte(strings.Join(currentFiles, "\n") + "\n")
 	indexPath := filepath.Join(dst, bundledSkillsIndex)
-	if have, err := os.ReadFile(indexPath); err == nil && bytes.Equal(have, index) {
-		return changed, nil
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
+	wrote, err := writeBundledSkillFile(dst, indexPath, index)
+	if err != nil {
 		return changed, err
 	}
-	if err := os.WriteFile(indexPath, index, 0o644); err != nil {
-		return changed, err
-	}
-	return true, nil
+	return changed || wrote, nil
 }
 
 func readBundledSkillsIndex(dst string) ([]string, error) {
-	b, err := os.ReadFile(filepath.Join(dst, bundledSkillsIndex))
+	indexPath := filepath.Join(dst, bundledSkillsIndex)
+	info, err := os.Lstat(indexPath)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("read bundled skills index %s: path is a symlink", indexPath)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("read bundled skills index %s: path is not a regular file", indexPath)
+	}
+	b, err := os.ReadFile(indexPath)
 	if err != nil {
 		return nil, err
 	}
@@ -196,6 +197,102 @@ func readBundledSkillsIndex(dst string) ([]string, error) {
 		paths = append(paths, path)
 	}
 	return paths, nil
+}
+
+// writeBundledSkillFile refuses to follow symlinks at a managed path or in a
+// bundled subtree. Writing through either could replace user data outside the
+// skills directory. A temporary regular file and rename also make the final
+// replacement atomic and prevent a last-component symlink race.
+func writeBundledSkillFile(dst, target string, want []byte) (bool, error) {
+	if err := ensureBundledSkillParent(dst, filepath.Dir(target)); err != nil {
+		return false, err
+	}
+
+	info, err := os.Lstat(target)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return false, fmt.Errorf("write bundled skill file %s: path is a symlink", target)
+		}
+		if !info.Mode().IsRegular() {
+			return false, fmt.Errorf("write bundled skill file %s: path is not a regular file", target)
+		}
+		have, err := os.ReadFile(target)
+		if err != nil {
+			return false, err
+		}
+		if bytes.Equal(have, want) {
+			return false, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(target), ".pier-skill-*")
+	if err != nil {
+		return false, err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		return false, err
+	}
+	if _, err := tmp.Write(want); err != nil {
+		tmp.Close()
+		return false, err
+	}
+	if err := tmp.Close(); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ensureBundledSkillParent creates directories below dst one at a time so an
+// existing symlink cannot redirect a bundled subtree. dst itself may be a
+// symlink because users commonly keep their whole agent config elsewhere.
+func ensureBundledSkillParent(dst, dir string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("skills path %s is not a directory", dst)
+	}
+
+	rel, err := filepath.Rel(dst, dir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("bundled skill directory %s is outside %s", dir, dst)
+	}
+	current := dst
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(current, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("write bundled skill directory %s: path is a symlink", current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("write bundled skill directory %s: path is not a directory", current)
+		}
+	}
+	return nil
 }
 
 // removeBundledSkillFile removes one path claimed by the previous ownership

--- a/internal/wizard/skills.go
+++ b/internal/wizard/skills.go
@@ -3,6 +3,9 @@ package wizard
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -75,22 +78,26 @@ func offerSkills(in *bufio.Reader, cfg *config.Config, home string) error {
 	}
 	saved := false
 	for _, agent := range chosen {
-		notes, err := InstallSkills(home, []string{agent})
+		notes, installErr := InstallSkills(home, []string{agent})
 		for _, n := range notes {
 			fmt.Println(n)
 		}
-		if err != nil {
-			return err
-		}
 
 		entry := agent + "/skills"
-		if len(cfg.Secrets.Manifest) > 0 && !slices.Contains(cfg.Secrets.Manifest, entry) {
+		// Cleanup/index bookkeeping can fail after every bundled file is safely
+		// in place. Verify the actual installation before deciding whether the
+		// directory belongs in the session manifest.
+		installed := installErr == nil || bundledSkillsCurrent(filepath.Join(home, entry))
+		if installed && len(cfg.Secrets.Manifest) > 0 && !slices.Contains(cfg.Secrets.Manifest, entry) {
 			cfg.Secrets.Manifest = append(cfg.Secrets.Manifest, entry)
 			if err := cfg.Save(); err != nil {
 				return err
 			}
 			saved = true
 			fmt.Println(ui.Dim.Render("    + ~/" + entry + " added to the session manifest"))
+		}
+		if installErr != nil {
+			return installErr
 		}
 	}
 	if saved {
@@ -101,19 +108,30 @@ func offerSkills(in *bufio.Reader, cfg *config.Config, home string) error {
 
 const bundledSkillsIndex = ".pier-bundled-files"
 
+type bundledSkillsIndexData struct {
+	Version int               `json:"version"`
+	Files   map[string]string `json:"files"`
+}
+
 // syncSkills refreshes every embedded file and removes paths that an earlier
 // bundle owned but the current bundle no longer contains. The ownership index
 // leaves untracked, user-created files alone, including additions within a
 // bundled skill directory. It reports whether anything was written or removed.
 func syncSkills(dst string) (changed bool, err error) {
-	current := make(map[string]struct{})
+	current := make(map[string]string)
+	contents := make(map[string][]byte)
 	var currentFiles []string
 	err = fs.WalkDir(skills.FS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if !d.IsDir() {
-			current[path] = struct{}{}
+			content, err := fs.ReadFile(skills.FS, path)
+			if err != nil {
+				return err
+			}
+			current[path] = bundledSkillHash(content)
+			contents[path] = content
 			currentFiles = append(currentFiles, path)
 		}
 		return nil
@@ -126,38 +144,30 @@ func syncSkills(dst string) (changed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	for _, path := range previousFiles {
+	for path, previousHash := range previousFiles {
 		if _, stillBundled := current[path]; stillBundled {
 			continue
 		}
-		removed, err := removeBundledSkillFile(dst, path)
+		removed, err := removeBundledSkillFile(dst, path, previousHash)
 		changed = changed || removed
 		if err != nil {
 			return changed, err
 		}
 	}
 
-	err = fs.WalkDir(skills.FS, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return err
-		}
-		want, err := fs.ReadFile(skills.FS, path)
-		if err != nil {
-			return err
-		}
+	for _, path := range currentFiles {
 		target := filepath.Join(dst, filepath.FromSlash(path))
-		wrote, err := writeBundledSkillFile(dst, target, want)
+		wrote, err := writeBundledSkillFile(dst, target, contents[path])
 		if err != nil {
-			return err
+			return changed, err
 		}
 		changed = changed || wrote
-		return nil
-	})
+	}
+
+	index, err := marshalBundledSkillsIndex(current)
 	if err != nil {
 		return changed, err
 	}
-
-	index := []byte(strings.Join(currentFiles, "\n") + "\n")
 	indexPath := filepath.Join(dst, bundledSkillsIndex)
 	wrote, err := writeBundledSkillFile(dst, indexPath, index)
 	if err != nil {
@@ -166,11 +176,11 @@ func syncSkills(dst string) (changed bool, err error) {
 	return changed || wrote, nil
 }
 
-func readBundledSkillsIndex(dst string) ([]string, error) {
+func readBundledSkillsIndex(dst string) (map[string]string, error) {
 	indexPath := filepath.Join(dst, bundledSkillsIndex)
 	info, err := os.Lstat(indexPath)
 	if os.IsNotExist(err) {
-		return nil, nil
+		return map[string]string{}, nil
 	}
 	if err != nil {
 		return nil, err
@@ -186,17 +196,53 @@ func readBundledSkillsIndex(dst string) ([]string, error) {
 		return nil, err
 	}
 
-	var paths []string
-	for _, path := range strings.Split(string(b), "\n") {
-		if path == "" {
-			continue
+	// The path-only format existed on this PR before hashes were introduced.
+	// Preserve those files rather than guessing ownership during migration.
+	if !bytes.HasPrefix(bytes.TrimSpace(b), []byte("{")) {
+		files := make(map[string]string)
+		for _, path := range strings.Split(string(b), "\n") {
+			if path == "" {
+				continue
+			}
+			if !validBundledSkillPath(path) {
+				return nil, fmt.Errorf("invalid path %q in %s", path, bundledSkillsIndex)
+			}
+			files[path] = ""
 		}
-		if path == "." || path == bundledSkillsIndex || !fs.ValidPath(path) || strings.Contains(path, `\`) {
+		return files, nil
+	}
+
+	var index bundledSkillsIndexData
+	if err := json.Unmarshal(b, &index); err != nil {
+		return nil, fmt.Errorf("read bundled skills index %s: %w", indexPath, err)
+	}
+	if index.Version != 1 || index.Files == nil {
+		return nil, fmt.Errorf("read bundled skills index %s: unsupported version %d", indexPath, index.Version)
+	}
+	for path, hash := range index.Files {
+		decoded, err := hex.DecodeString(hash)
+		if !validBundledSkillPath(path) || err != nil || len(decoded) != sha256.Size {
 			return nil, fmt.Errorf("invalid path %q in %s", path, bundledSkillsIndex)
 		}
-		paths = append(paths, path)
 	}
-	return paths, nil
+	return index.Files, nil
+}
+
+func marshalBundledSkillsIndex(files map[string]string) ([]byte, error) {
+	b, err := json.MarshalIndent(bundledSkillsIndexData{Version: 1, Files: files}, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+func validBundledSkillPath(path string) bool {
+	return path != "." && path != bundledSkillsIndex && fs.ValidPath(path) && !strings.Contains(path, `\`)
+}
+
+func bundledSkillHash(content []byte) string {
+	hash := sha256.Sum256(content)
+	return hex.EncodeToString(hash[:])
 }
 
 // writeBundledSkillFile refuses to follow symlinks at a managed path or in a
@@ -254,8 +300,18 @@ func writeBundledSkillFile(dst, target string, want []byte) (bool, error) {
 // existing symlink cannot redirect a bundled subtree. dst itself may be a
 // symlink because users commonly keep their whole agent config elsewhere.
 func ensureBundledSkillParent(dst, dir string) error {
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return err
+	return bundledSkillParent(dst, dir, true)
+}
+
+func checkBundledSkillParent(dst, dir string) error {
+	return bundledSkillParent(dst, dir, false)
+}
+
+func bundledSkillParent(dst, dir string, create bool) error {
+	if create {
+		if err := os.MkdirAll(dst, 0o755); err != nil {
+			return err
+		}
 	}
 	info, err := os.Stat(dst)
 	if err != nil {
@@ -276,7 +332,7 @@ func ensureBundledSkillParent(dst, dir string) error {
 		}
 		current = filepath.Join(current, part)
 		info, err := os.Lstat(current)
-		if os.IsNotExist(err) {
+		if create && os.IsNotExist(err) {
 			if err := os.Mkdir(current, 0o755); err != nil {
 				return err
 			}
@@ -295,10 +351,13 @@ func ensureBundledSkillParent(dst, dir string) error {
 	return nil
 }
 
-// removeBundledSkillFile removes one path claimed by the previous ownership
-// index, then prunes only empty parent directories. A directory where the
-// index promised a file is left intact because it may contain user data.
-func removeBundledSkillFile(dst, path string) (bool, error) {
+// removeBundledSkillFile removes a formerly bundled path only while its
+// contents still match what Pier wrote. Modified, recreated, legacy-indexed,
+// and non-regular paths are user-owned and deliberately preserved.
+func removeBundledSkillFile(dst, path, previousHash string) (bool, error) {
+	if previousHash == "" {
+		return false, nil
+	}
 	target := filepath.Join(dst, filepath.FromSlash(path))
 	info, err := os.Lstat(target)
 	if os.IsNotExist(err) {
@@ -307,13 +366,55 @@ func removeBundledSkillFile(dst, path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if info.IsDir() {
-		return false, fmt.Errorf("remove obsolete bundled file %s: path is now a directory", target)
+	if !info.Mode().IsRegular() {
+		return false, nil
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		return false, err
+	}
+	if bundledSkillHash(content) != previousHash {
+		return false, nil
 	}
 	if err := os.Remove(target); err != nil {
 		return false, err
 	}
 	return true, pruneEmptySkillDirs(filepath.Dir(target), dst)
+}
+
+// bundledSkillsCurrent checks usability independently of cleanup metadata.
+// The wizard uses it after an error so an already-complete installation is
+// still carried into sessions, while an absent or partial installation is not.
+func bundledSkillsCurrent(dst string) bool {
+	err := fs.WalkDir(skills.FS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		want, err := fs.ReadFile(skills.FS, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, filepath.FromSlash(path))
+		if err := checkBundledSkillParent(dst, filepath.Dir(target)); err != nil {
+			return err
+		}
+		info, err := os.Lstat(target)
+		if err != nil || !info.Mode().IsRegular() {
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("bundled skill file %s is not regular", target)
+		}
+		have, err := os.ReadFile(target)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(have, want) {
+			return fmt.Errorf("bundled skill file %s is not current", target)
+		}
+		return nil
+	})
+	return err == nil
 }
 
 func pruneEmptySkillDirs(dir, stop string) error {

--- a/internal/wizard/skills_test.go
+++ b/internal/wizard/skills_test.go
@@ -13,9 +13,17 @@ import (
 
 // TestInstallSkills covers the lifecycle: no agents → nothing to do,
 // claude only → claude gets the skill, re-run → no rewrite, stale copy →
-// refreshed, codex appears → codex gets it too.
+// refreshed, obsolete bundled file → removed, codex appears → codex gets it too.
 func TestInstallSkills(t *testing.T) {
 	home := t.TempDir()
+	install := func() []string {
+		t.Helper()
+		notes, err := InstallSkills(home, AgentDirs(home))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return notes
+	}
 
 	if dirs := AgentDirs(home); len(dirs) != 0 {
 		t.Fatalf("no agents on the machine, got %q", dirs)
@@ -27,7 +35,7 @@ func TestInstallSkills(t *testing.T) {
 	if dirs := AgentDirs(home); !slices.Equal(dirs, []string{".claude"}) {
 		t.Fatalf("want just .claude, got %q", dirs)
 	}
-	notes := InstallSkills(home, AgentDirs(home))
+	notes := install()
 	if len(notes) != 1 || !strings.Contains(notes[0], "installed") {
 		t.Fatalf("want one install note, got %q", notes)
 	}
@@ -47,28 +55,77 @@ func TestInstallSkills(t *testing.T) {
 		t.Fatal(".codex was conjured for a machine without codex")
 	}
 
-	if notes := InstallSkills(home, AgentDirs(home)); len(notes) != 1 || !strings.Contains(notes[0], "up to date") {
+	if notes := install(); len(notes) != 1 || !strings.Contains(notes[0], "up to date") {
 		t.Fatalf("second run should be a no-op, got %q", notes)
 	}
 
 	if err := os.WriteFile(claudeSkill, []byte("stale"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if notes := InstallSkills(home, AgentDirs(home)); len(notes) != 1 || !strings.Contains(notes[0], "installed") {
+	if notes := install(); len(notes) != 1 || !strings.Contains(notes[0], "installed") {
 		t.Fatalf("stale copy should refresh, got %q", notes)
 	}
 	if b, _ := os.ReadFile(claudeSkill); string(b) == "stale" {
 		t.Fatal("stale skill was not refreshed")
 	}
 
+	obsolete := filepath.Join(home, ".claude/skills/pier-onboard/obsolete.md")
+	if err := os.WriteFile(obsolete, []byte("removed from a later bundle"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	customSkill := filepath.Join(home, ".claude/skills/custom/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(customSkill), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(customSkill, []byte("user managed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if notes := install(); len(notes) != 1 || !strings.Contains(notes[0], "installed") {
+		t.Fatalf("obsolete bundled file should be removed, got %q", notes)
+	}
+	if _, err := os.Stat(obsolete); !os.IsNotExist(err) {
+		t.Fatalf("obsolete bundled file remains: %v", err)
+	}
+	if b, err := os.ReadFile(customSkill); err != nil || string(b) != "user managed" {
+		t.Fatalf("sibling user skill changed: %q, %v", b, err)
+	}
+
 	if err := os.Mkdir(filepath.Join(home, ".codex"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if notes := InstallSkills(home, AgentDirs(home)); len(notes) != 2 {
+	if notes := install(); len(notes) != 2 {
 		t.Fatalf("want claude+codex notes, got %q", notes)
 	}
 	if _, err := os.Stat(filepath.Join(home, ".codex/skills/pier-onboard/SKILL.md")); err != nil {
 		t.Fatalf("codex skill missing: %v", err)
+	}
+}
+
+func TestInstallSkillsReturnsErrorsBeforeManifestSave(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude/skills"), []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	notes, err := InstallSkills(home, []string{".claude"})
+	if err == nil {
+		t.Fatal("install into an invalid skills path succeeded")
+	}
+	if len(notes) != 0 {
+		t.Fatalf("failed install returned success notes: %q", notes)
+	}
+
+	cfg := config.Default()
+	cfg.Secrets.Manifest = []string{".claude/settings.json"}
+	err = offerSkills(bufio.NewReader(strings.NewReader("y\n")), &cfg, home)
+	if err == nil {
+		t.Fatal("wizard ignored skill installation failure")
+	}
+	if slices.Contains(cfg.Secrets.Manifest, ".claude/skills") {
+		t.Fatalf("failed skill destination entered manifest: %q", cfg.Secrets.Manifest)
 	}
 }
 

--- a/internal/wizard/skills_test.go
+++ b/internal/wizard/skills_test.go
@@ -1,0 +1,123 @@
+package wizard
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/usepier/pier/internal/config"
+)
+
+// TestInstallSkills covers the lifecycle: no agents → nothing to do,
+// claude only → claude gets the skill, re-run → no rewrite, stale copy →
+// refreshed, codex appears → codex gets it too.
+func TestInstallSkills(t *testing.T) {
+	home := t.TempDir()
+
+	if dirs := AgentDirs(home); len(dirs) != 0 {
+		t.Fatalf("no agents on the machine, got %q", dirs)
+	}
+
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if dirs := AgentDirs(home); !slices.Equal(dirs, []string{".claude"}) {
+		t.Fatalf("want just .claude, got %q", dirs)
+	}
+	notes := InstallSkills(home, AgentDirs(home))
+	if len(notes) != 1 || !strings.Contains(notes[0], "installed") {
+		t.Fatalf("want one install note, got %q", notes)
+	}
+	claudeSkill := filepath.Join(home, ".claude/skills/pier-onboard/SKILL.md")
+	b, err := os.ReadFile(claudeSkill)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The frontmatter both Claude Code and Codex require, with the name
+	// matching the directory.
+	for _, want := range []string{"name: pier-onboard", "description:"} {
+		if !strings.Contains(string(b), want) {
+			t.Errorf("SKILL.md missing %q", want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex")); !os.IsNotExist(err) {
+		t.Fatal(".codex was conjured for a machine without codex")
+	}
+
+	if notes := InstallSkills(home, AgentDirs(home)); len(notes) != 1 || !strings.Contains(notes[0], "up to date") {
+		t.Fatalf("second run should be a no-op, got %q", notes)
+	}
+
+	if err := os.WriteFile(claudeSkill, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if notes := InstallSkills(home, AgentDirs(home)); len(notes) != 1 || !strings.Contains(notes[0], "installed") {
+		t.Fatalf("stale copy should refresh, got %q", notes)
+	}
+	if b, _ := os.ReadFile(claudeSkill); string(b) == "stale" {
+		t.Fatal("stale skill was not refreshed")
+	}
+
+	if err := os.Mkdir(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if notes := InstallSkills(home, AgentDirs(home)); len(notes) != 2 {
+		t.Fatalf("want claude+codex notes, got %q", notes)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex/skills/pier-onboard/SKILL.md")); err != nil {
+		t.Fatalf("codex skill missing: %v", err)
+	}
+}
+
+// TestOfferSkills drives the wizard step through scripted stdin: per-agent
+// confirms gate the install, and a confirmed skills dir joins the session
+// manifest only when the user opted into copying agent config at all.
+func TestOfferSkills(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home) // cfg.Save writes under $HOME
+	for _, agent := range []string{".claude", ".codex"} {
+		if err := os.Mkdir(filepath.Join(home, agent), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// claude yes, codex no; manifest already opted-in.
+	cfg := config.Default()
+	cfg.Secrets.Manifest = []string{".claude/settings.json"}
+	if err := offerSkills(bufio.NewReader(strings.NewReader("y\nn\n")), &cfg, home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude/skills/pier-onboard/SKILL.md")); err != nil {
+		t.Fatalf("claude skill missing after yes: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex/skills")); !os.IsNotExist(err) {
+		t.Fatal("codex skills installed despite no")
+	}
+	if !slices.Contains(cfg.Secrets.Manifest, ".claude/skills") {
+		t.Fatalf("confirmed skills dir not in manifest: %q", cfg.Secrets.Manifest)
+	}
+	if slices.Contains(cfg.Secrets.Manifest, ".codex/skills") {
+		t.Fatalf("declined agent entered the manifest: %q", cfg.Secrets.Manifest)
+	}
+	saved, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(saved.Secrets.Manifest, ".claude/skills") {
+		t.Fatalf("manifest append was not saved: %q", saved.Secrets.Manifest)
+	}
+
+	// Empty manifest = the user said no to copying agent config; installing
+	// the skill locally must not sneak entries in.
+	cfg2 := config.Default()
+	cfg2.Secrets.Manifest = nil
+	if err := offerSkills(bufio.NewReader(strings.NewReader("y\ny\n")), &cfg2, home); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg2.Secrets.Manifest) != 0 {
+		t.Fatalf("opted-out manifest gained entries: %q", cfg2.Secrets.Manifest)
+	}
+}

--- a/internal/wizard/skills_test.go
+++ b/internal/wizard/skills_test.go
@@ -71,16 +71,26 @@ func TestInstallSkills(t *testing.T) {
 	}
 
 	obsolete := filepath.Join(home, ".claude/skills/pier-onboard/obsolete.md")
-	if err := os.WriteFile(obsolete, []byte("removed from a later bundle"), 0o644); err != nil {
+	obsoleteContent := []byte("removed from a later bundle")
+	if err := os.WriteFile(obsolete, obsoleteContent, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	indexPath := filepath.Join(home, ".claude/skills", bundledSkillsIndex)
-	index, err := os.ReadFile(indexPath)
+	index, err := readBundledSkillsIndex(filepath.Dir(indexPath))
 	if err != nil {
 		t.Fatal(err)
 	}
-	index = append(index, "pier-onboard/obsolete.md\n"...)
-	if err := os.WriteFile(indexPath, index, 0o644); err != nil {
+	index["pier-onboard/obsolete.md"] = bundledSkillHash(obsoleteContent)
+	replacement := filepath.Join(home, ".claude/skills/pier-onboard/replaced.md")
+	index["pier-onboard/replaced.md"] = bundledSkillHash([]byte("old bundled content"))
+	if err := os.WriteFile(replacement, []byte("user replacement"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	encodedIndex, err := marshalBundledSkillsIndex(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(indexPath, encodedIndex, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	customReference := filepath.Join(home, ".claude/skills/pier-onboard/custom.md")
@@ -99,6 +109,9 @@ func TestInstallSkills(t *testing.T) {
 	}
 	if _, err := os.Stat(obsolete); !os.IsNotExist(err) {
 		t.Fatalf("obsolete bundled file remains: %v", err)
+	}
+	if b, err := os.ReadFile(replacement); err != nil || string(b) != "user replacement" {
+		t.Fatalf("user replacement of obsolete file changed: %q, %v", b, err)
 	}
 	if b, err := os.ReadFile(customReference); err != nil || string(b) != "user managed" {
 		t.Fatalf("user reference inside bundled skill changed: %q, %v", b, err)
@@ -208,6 +221,41 @@ func TestOfferSkillsPersistsSuccessBeforeLaterFailure(t *testing.T) {
 	}
 	if !slices.Contains(saved.Secrets.Manifest, ".claude/skills") {
 		t.Fatalf("successful first install was not saved: %q", saved.Secrets.Manifest)
+	}
+}
+
+func TestOfferSkillsPersistsCurrentSkillWhenIndexFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallSkills(home, []string{".claude"}); err != nil {
+		t.Fatal(err)
+	}
+	indexPath := filepath.Join(home, ".claude/skills", bundledSkillsIndex)
+	if err := os.Remove(indexPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(indexPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Default()
+	cfg.Secrets.Manifest = []string{".claude/settings.json"}
+	err := offerSkills(bufio.NewReader(strings.NewReader("y\n")), &cfg, home)
+	if err == nil {
+		t.Fatal("wizard ignored ownership index failure")
+	}
+	if !slices.Contains(cfg.Secrets.Manifest, ".claude/skills") {
+		t.Fatalf("current skill missing from manifest after index failure: %q", cfg.Secrets.Manifest)
+	}
+	saved, loadErr := config.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if !slices.Contains(saved.Secrets.Manifest, ".claude/skills") {
+		t.Fatalf("current skill was not saved after index failure: %q", saved.Secrets.Manifest)
 	}
 }
 

--- a/internal/wizard/skills_test.go
+++ b/internal/wizard/skills_test.go
@@ -146,6 +146,38 @@ func TestInstallSkillsReturnsErrorsBeforeManifestSave(t *testing.T) {
 	}
 }
 
+func TestInstallSkillsRefusesSymlinkedBundledFile(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallSkills(home, []string{".claude"}); err != nil {
+		t.Fatal(err)
+	}
+
+	skill := filepath.Join(home, ".claude/skills/pier-onboard/SKILL.md")
+	external := filepath.Join(home, "user-managed.md")
+	if err := os.WriteFile(external, []byte("do not overwrite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(skill); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, skill); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := InstallSkills(home, []string{".claude"}); err == nil {
+		t.Fatal("refresh followed a symlinked bundled file")
+	}
+	if b, err := os.ReadFile(external); err != nil || string(b) != "do not overwrite" {
+		t.Fatalf("external symlink target changed: %q, %v", b, err)
+	}
+	if info, err := os.Lstat(skill); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("user-managed symlink changed: %v, %v", info, err)
+	}
+}
+
 func TestOfferSkillsPersistsSuccessBeforeLaterFailure(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/wizard/skills_test.go
+++ b/internal/wizard/skills_test.go
@@ -13,7 +13,8 @@ import (
 
 // TestInstallSkills covers the lifecycle: no agents → nothing to do,
 // claude only → claude gets the skill, re-run → no rewrite, stale copy →
-// refreshed, obsolete bundled file → removed, codex appears → codex gets it too.
+// refreshed, obsolete owned file → removed, user file → preserved, codex
+// appears → codex gets it too.
 func TestInstallSkills(t *testing.T) {
 	home := t.TempDir()
 	install := func() []string {
@@ -73,6 +74,19 @@ func TestInstallSkills(t *testing.T) {
 	if err := os.WriteFile(obsolete, []byte("removed from a later bundle"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	indexPath := filepath.Join(home, ".claude/skills", bundledSkillsIndex)
+	index, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	index = append(index, "pier-onboard/obsolete.md\n"...)
+	if err := os.WriteFile(indexPath, index, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	customReference := filepath.Join(home, ".claude/skills/pier-onboard/custom.md")
+	if err := os.WriteFile(customReference, []byte("user managed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	customSkill := filepath.Join(home, ".claude/skills/custom/SKILL.md")
 	if err := os.MkdirAll(filepath.Dir(customSkill), 0o755); err != nil {
 		t.Fatal(err)
@@ -85,6 +99,9 @@ func TestInstallSkills(t *testing.T) {
 	}
 	if _, err := os.Stat(obsolete); !os.IsNotExist(err) {
 		t.Fatalf("obsolete bundled file remains: %v", err)
+	}
+	if b, err := os.ReadFile(customReference); err != nil || string(b) != "user managed" {
+		t.Fatalf("user reference inside bundled skill changed: %q, %v", b, err)
 	}
 	if b, err := os.ReadFile(customSkill); err != nil || string(b) != "user managed" {
 		t.Fatalf("sibling user skill changed: %q, %v", b, err)
@@ -126,6 +143,39 @@ func TestInstallSkillsReturnsErrorsBeforeManifestSave(t *testing.T) {
 	}
 	if slices.Contains(cfg.Secrets.Manifest, ".claude/skills") {
 		t.Fatalf("failed skill destination entered manifest: %q", cfg.Secrets.Manifest)
+	}
+}
+
+func TestOfferSkillsPersistsSuccessBeforeLaterFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, agent := range []string{".claude", ".codex"} {
+		if err := os.Mkdir(filepath.Join(home, agent), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(home, ".codex/skills"), []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Default()
+	cfg.Secrets.Manifest = []string{".claude/settings.json"}
+	err := offerSkills(bufio.NewReader(strings.NewReader("y\ny\n")), &cfg, home)
+	if err == nil {
+		t.Fatal("wizard ignored second skill installation failure")
+	}
+	if !slices.Contains(cfg.Secrets.Manifest, ".claude/skills") {
+		t.Fatalf("successful first install missing from manifest: %q", cfg.Secrets.Manifest)
+	}
+	if slices.Contains(cfg.Secrets.Manifest, ".codex/skills") {
+		t.Fatalf("failed second install entered manifest: %q", cfg.Secrets.Manifest)
+	}
+	saved, loadErr := config.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if !slices.Contains(saved.Secrets.Manifest, ".claude/skills") {
+		t.Fatalf("successful first install was not saved: %q", saved.Secrets.Manifest)
 	}
 }
 

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -1,5 +1,6 @@
 // Package wizard implements `pier setup`: detect → ask (plain prompts, ≤6
-// questions) → apply groundwork → doctor → write config → offer bake.
+// questions) → apply groundwork → doctor → write config → offer skills →
+// offer bake.
 // Everything detected becomes a prefilled default, so a second dev on a
 // prepared account just presses enter a few times.
 package wizard
@@ -213,7 +214,15 @@ func Run(newDriver func(config.Config) (driver.Driver, error), printAdminOnly bo
 		fmt.Println(line)
 	}
 
-	// 5. offer bake — images are repo-specific, so only when the wizard runs
+	// 5. offer the bundled skills — per-agent confirms, before bake so no
+	// question hides behind a ~5 min build.
+	if home, err := os.UserHomeDir(); err == nil {
+		if err := offerSkills(in, &cfg, home); err != nil {
+			return err
+		}
+	}
+
+	// 6. offer bake — images are repo-specific, so only when the wizard runs
 	// inside a repo; otherwise point at `pier bake` from one.
 	fmt.Println()
 	if repo := gitToplevel(); repo == "" {

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -1,0 +1,13 @@
+// Package skills ships the agent skills bundled with pier, embedded so the
+// installed binary can lay them down (`pier setup`) without a repo checkout
+// — brew users never see this directory.
+package skills
+
+import "embed"
+
+// FS holds every bundled skill, one directory per skill (<name>/SKILL.md
+// plus any reference files) in the Agent Skills layout that Claude Code and
+// Codex both read.
+//
+//go:embed pier-onboard
+var FS embed.FS


### PR DESCRIPTION
## What

The pier-onboard skill previously existed only as a file in the repo with a manual `cp -r` instruction in the README — invisible to brew users, who have no checkout. This embeds the skill in the pier binary and installs it where agents actually look for it.

- **`skills/embed.go`** — embeds `skills/pier-onboard` via `go:embed`, so the installed binary needs no repo checkout.
- **Setup wizard step** — new phase at the end of `pier setup` (after doctor, before the bake offer so no question hides behind the ~5 min build): one Y/n confirm per agent detected on the machine. Claude Code (`~/.claude/skills`) and Codex (`~/.codex/skills`) read the same SKILL.md layout, so one embedded tree serves both; agents without a config dir are never offered (pier must not conjure agents the machine doesn't run).
- **Manifest follow-up** — a skills dir created by the confirm postdates manifest detection on first runs, so it's appended to the session manifest and the config re-saved, letting the skill ride into session VMs. Skipped when the user opted out of copying agent config entirely.
- **`pier skills`** — the same install standalone and non-interactive (running the command is the confirmation; stays scriptable). Idempotent: unchanged files are skipped, stale copies from an older pier are refreshed.

## Tests

- `TestInstallSkills`: lifecycle — no agents → nothing conjured, install, no-op re-run, stale refresh, second agent appearing later.
- `TestOfferSkills`: drives the wizard step via scripted stdin — per-agent gating, manifest append persisted, opt-out-manifest guard.
- `go vet ./... && go test -race ./...` green, gofmt clean; standalone command smoke-tested against throwaway $HOMEs (install / up-to-date / no-agents paths).

## Docs

README's manual `cp -r` instruction replaced with the wizard/`pier skills` flow; SPEC §8 manifest sources mention skills, §9 wizard is now five phases, §11 CLI list gains `pier skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)