### PR TITLE
fix: make failed creates visible and config writes safe

### DIFF
--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -1102,9 +1102,10 @@ func cmdTUI() {
 // createLogPath is where a detached create's output lands. spawnCreate writes
 // it and the create itself reads it back to point its tombstone at the log —
 // so the formula lives here once rather than being re-derived on both sides.
+// It shares the graveyard's escaping, so feat/login and feat-login get their
+// own logs instead of overwriting each other's.
 func createLogPath(branch string) string {
-	return filepath.Join(config.Dir(), "logs",
-		"create-"+strings.ReplaceAll(branch, "/", "-")+".log")
+	return filepath.Join(config.Dir(), "logs", "create-"+tombstone.FileStem(branch)+".log")
 }
 
 // listSessions is the one list every surface shows: the driver's real

--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/usepier/pier/internal/driver/gcpgce"
 	"github.com/usepier/pier/internal/driver/payload"
 	"github.com/usepier/pier/internal/proxy"
+	"github.com/usepier/pier/internal/tombstone"
 	"github.com/usepier/pier/internal/tui"
 	"github.com/usepier/pier/internal/ui"
 	"github.com/usepier/pier/internal/wizard"
@@ -266,6 +267,16 @@ func cmdNew(args []string) {
 	// Images are repo-specific; a repo that never baked launches from stock
 	// (guarded cloud-init installs live).
 	image := cfg.BakedImage(filepath.Base(repo))
+	// A repo with a bake hook has declared that stock isn't enough for it —
+	// its toolchain lives in .pier/bake.sh and nowhere else. Launching stock
+	// anyway is legal but almost never what was wanted: the create succeeds,
+	// then .pier/setup.sh dies minutes later on a missing toolchain, and the
+	// two events look unrelated. Say it here, while it's still one sentence.
+	if image == "" && driver.BakeHook(repo) != "" {
+		fmt.Println(ui.Warn.Render("!") + ui.Dim.Render(" no baked image for "+filepath.Base(repo)+
+			" — launching from stock, so .pier/bake.sh toolchains will be missing and .pier/setup.sh may fail"))
+		fmt.Println(ui.Dim.Render("  fix: `pier bake` in this repo (~5 min once)"))
+	}
 	fmt.Printf("%s %s\n", ui.Bold.Render("creating "+branch),
 		ui.Dim.Render(fmt.Sprintf("(%s @ %s)", filepath.Base(repo), base)))
 	sess, err := drv.Create(ctx, driver.CreateSpec{
@@ -274,6 +285,10 @@ func cmdNew(args []string) {
 		Progress: func(step string) { fmt.Println(ui.Step(step)) },
 	})
 	if err != nil {
+		// The instance is already gone (Create destroys its own wreckage), so
+		// leave a tombstone: without one this create vanishes without trace,
+		// and a detached create has no terminal to have shown the error in.
+		buryCreate(cfg, branch, repo, err)
 		fatal(err)
 	}
 	stop() // create done — ctrl-c back to its default for the prompt + attach
@@ -374,24 +389,33 @@ func waitReachable(drv driver.Driver, id string, timeout time.Duration) error {
 
 func cmdLS() {
 	_, drv := loadDriver()
-	sessions, err := drv.List(context.Background())
+	sessions, err := listSessions(drv)
 	if err != nil {
 		fatal(err)
 	}
-	enrich(drv, sessions)
 	if len(sessions) == 0 {
 		fmt.Println(ui.Dim.Render("no sessions — start one with `pier <branch>`"))
 		return
 	}
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tREPO\tSTATE\tAGE\tCOST")
-	anyStrained, anySetupFailed := false, false
+	anyStrained, anySetupFailed, anyFailedCreate := false, false, false
 	for _, s := range sessions {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", s.Name, s.Repo, stateLabel(s), age(s.Created), s.CostNote)
 		anyStrained = anyStrained || s.Strained
 		anySetupFailed = anySetupFailed || s.Setup == "failed"
+		anyFailedCreate = anyFailedCreate || s.State == driver.StateFailed
 	}
 	w.Flush()
+	if anyFailedCreate {
+		fmt.Println("\n" + ui.Bad.Render("✗") + ui.Dim.Render(" create failed = the instance was rolled back, nothing is running — `pier rm <session>` clears the row"))
+		for _, s := range sessions {
+			if s.State != driver.StateFailed || s.FailReason == "" {
+				continue
+			}
+			fmt.Println(ui.Dim.Render("  " + s.Name + ": " + tombstone.Summarize(s.FailReason)))
+		}
+	}
 	if anyStrained {
 		fmt.Println("\n" + ui.Warn.Render("!") + ui.Dim.Render(" strained = sustained cpu/mem pressure — grow with `pier resize <session> <type>`"))
 	}
@@ -402,6 +426,12 @@ func cmdLS() {
 
 // stateLabel renders the state plus the supervisor's strain and setup flags.
 func stateLabel(s driver.Session) string {
+	if s.State == driver.StateFailed {
+		// "create failed", never a bare "failed": the neighbouring rows say
+		// "setup failed" for a live session whose setup script died, and the
+		// two mean very different things — one has a VM, this one does not.
+		return "create failed"
+	}
 	l := string(s.State)
 	if s.Strained {
 		l += " (strained)"
@@ -485,7 +515,7 @@ func age(t time.Time) string {
 }
 
 func match(drv driver.Driver, query string) driver.Session {
-	sessions, err := drv.List(context.Background())
+	sessions, err := listSessions(drv)
 	if err != nil {
 		fatal(err)
 	}
@@ -548,6 +578,22 @@ func cmdLogs(args []string) {
 // interprets the progress-meter escapes natively. The TUI's l key renders a
 // sanitized in-place view instead.
 func showLogs(drv driver.Driver, s driver.Session, follow bool) {
+	// A failed create has no VM and no setup log, but it does have the create
+	// log — which is the log the user is asking for. Serve that instead of
+	// refusing: "what broke" is the same question either way.
+	if s.State == driver.StateFailed {
+		if s.LogPath == "" {
+			fmt.Println(s.FailReason)
+			return
+		}
+		b, err := os.ReadFile(s.LogPath)
+		if err != nil {
+			fmt.Println(s.FailReason)
+			return
+		}
+		os.Stdout.Write(b)
+		return
+	}
 	requireReady(s)
 	if s.State == driver.StateParked {
 		resumeIfParked(drv, s)
@@ -575,6 +621,14 @@ func showLogs(drv driver.Driver, s driver.Session, follow bool) {
 // before any ssh is spawned, so the user never sees a raw transport error
 // from the window between cloud-running and actually-attachable.
 func requireReady(s driver.Session) {
+	if s.State == driver.StateFailed {
+		hint := "`pier " + s.Name + "` retries it"
+		if s.LogPath != "" {
+			hint += ", " + s.LogPath + " has the create log"
+		}
+		fatal(fmt.Errorf("%s never finished creating (%s) — nothing is running; %s",
+			s.Name, tombstone.Summarize(s.FailReason), hint))
+	}
 	if s.State == driver.StateCreating {
 		fatal(fmt.Errorf("%s is still setting up — try again when `pier ls` shows it running", s.Name))
 	}
@@ -775,6 +829,14 @@ func cmdRM(args []string) {
 	}
 	_, drv := loadDriver()
 	s := match(drv, names[0])
+	// A tombstone has no instance and no disk — rm just forgets the record.
+	if s.State == driver.StateFailed {
+		if err := tombstone.Dismiss(config.Dir(), s.Name); err != nil {
+			fatal(err)
+		}
+		fmt.Println(ui.OK.Render("cleared failed create " + s.Name))
+		return
+	}
 	if !force && !confirm(fmt.Sprintf("destroy session %q and its disk?", s.Name), false) {
 		return
 	}
@@ -910,23 +972,32 @@ func cmdBake() {
 	if err != nil {
 		fatal(err)
 	}
-	cfg.RecordBake(name, img)
-	if err := cfg.Save(); err != nil {
+	// Update, not Save: a bake takes minutes, and cfg was read before it
+	// started. Saving it wholesale would revert anything written meanwhile —
+	// including another repo's bake.
+	if _, err := config.Update(func(c *config.Config) error {
+		c.RecordBake(name, img)
+		return nil
+	}); err != nil {
 		fatal(err)
 	}
 	fmt.Println(ui.OK.Render("baked "+img) + ui.Dim.Render(" — new "+name+" sessions now cold-start in ~1-2 min"))
 }
 
 func cmdTeardown() {
-	cfg, drv := loadDriver()
+	_, drv := loadDriver()
 	if !confirm("remove all pier groundwork and baked images from the account?", false) {
 		return
 	}
 	if err := drv.Teardown(context.Background()); err != nil {
 		fatal(err)
 	}
-	cfg.ClearBakes()
-	cfg.Save()
+	if _, err := config.Update(func(c *config.Config) error {
+		c.ClearBakes()
+		return nil
+	}); err != nil {
+		fatal(err)
+	}
 	fmt.Println(ui.OK.Render("groundwork removed — the account is clean"))
 }
 
@@ -957,14 +1028,7 @@ func cmdTUI() {
 			}
 			return q.Detail
 		},
-		Fetch: func() ([]driver.Session, error) {
-			sessions, err := drv.List(context.Background())
-			if err != nil {
-				return nil, err
-			}
-			enrich(drv, sessions)
-			return sessions, nil
-		},
+		Fetch:       func() ([]driver.Session, error) { return listSessions(drv) },
 		AuthExpired: awsec2.LoginExpired,
 		Reauthenticate: func() *exec.Cmd {
 			args := []string{"login"}
@@ -974,6 +1038,10 @@ func cmdTUI() {
 			return exec.Command("aws", args...)
 		},
 		Destroy: func(s driver.Session) error {
+			// d on a tombstone clears the record; there is no instance to kill.
+			if s.State == driver.StateFailed {
+				return tombstone.Dismiss(config.Dir(), s.Name)
+			}
 			return drv.Destroy(context.Background(), s.ID)
 		},
 		Pin: func(s driver.Session) error {
@@ -996,6 +1064,15 @@ func cmdTUI() {
 		},
 		CreateDetached: spawnCreate,
 		FetchLog: func(s driver.Session) (string, error) {
+			// A tombstone has no VM to read from — its log is the local create
+			// log, which is the whole point of keeping the row around.
+			if s.State == driver.StateFailed {
+				b, err := os.ReadFile(s.LogPath)
+				if err != nil {
+					return s.FailReason, nil
+				}
+				return string(b), nil
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			// The viewer refetches every few seconds, so the transfer stays
@@ -1022,6 +1099,74 @@ func cmdTUI() {
 	}
 }
 
+// createLogPath is where a detached create's output lands. spawnCreate writes
+// it and the create itself reads it back to point its tombstone at the log —
+// so the formula lives here once rather than being re-derived on both sides.
+func createLogPath(branch string) string {
+	return filepath.Join(config.Dir(), "logs",
+		"create-"+strings.ReplaceAll(branch, "/", "-")+".log")
+}
+
+// listSessions is the one list every surface shows: the driver's real
+// sessions plus local tombstones for creates that died before becoming one.
+// A tombstone whose name came back as a live session (the retry worked) is
+// dropped here, so a successful re-create silently clears its own gravestone.
+func listSessions(drv driver.Driver) ([]driver.Session, error) {
+	sessions, err := drv.List(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	enrich(drv, sessions)
+	merged, revived := mergeTombstones(sessions, tombstone.List(config.Dir()))
+	for _, name := range revived {
+		tombstone.Dismiss(config.Dir(), name)
+	}
+	return merged, nil
+}
+
+// mergeTombstones appends a failed row per tombstone and reports the ones the
+// cloud has since answered for. A name that is live again means the create
+// was retried and worked, so its gravestone is stale — the user shouldn't
+// have to clear a row that the obvious next action already resolved.
+func mergeTombstones(sessions []driver.Session, recs []tombstone.Record) (merged []driver.Session, revived []string) {
+	live := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		live[s.Name] = true
+	}
+	for _, r := range recs {
+		if live[r.Name] {
+			revived = append(revived, r.Name)
+			continue
+		}
+		sessions = append(sessions, driver.Session{
+			Name: r.Name, Repo: r.Repo, Branch: r.Branch, Driver: r.Driver,
+			State: driver.StateFailed, Created: r.When,
+			FailReason: r.Reason, LogPath: r.LogPath,
+			CostNote: "—", // nothing is running; nothing is being charged
+		})
+	}
+	return sessions, revived
+}
+
+// buryCreate records a failed create so it leaves a trace in the list instead
+// of a silent gap. Best-effort: the create already failed and its own error is
+// what the user acts on — a graveyard write that fails must not mask it.
+func buryCreate(cfg config.Config, branch, repo string, cause error) {
+	rec := tombstone.Record{
+		Name: branch, Repo: filepath.Base(repo), Branch: branch,
+		Driver: or(cfg.Driver, "aws-ec2"), Reason: cause.Error(), When: time.Now(),
+	}
+	if p := createLogPath(branch); fileExists(p) {
+		rec.LogPath = p
+	}
+	_ = tombstone.Write(config.Dir(), rec)
+}
+
+func fileExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && !fi.IsDir()
+}
+
 // spawnCreate re-execs `pier <branch> --detach` as a detached child (own
 // session, output to a log file), so a TUI-initiated create runs in the
 // background and survives the TUI closing. The list shows it as "creating"
@@ -1034,11 +1179,10 @@ func spawnCreate(branch string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	logDir := filepath.Join(config.Dir(), "logs")
-	if err := os.MkdirAll(logDir, 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Join(config.Dir(), "logs"), 0o700); err != nil {
 		return "", err
 	}
-	logPath := filepath.Join(logDir, "create-"+strings.ReplaceAll(branch, "/", "-")+".log")
+	logPath := createLogPath(branch)
 	f, err := os.Create(logPath)
 	if err != nil {
 		return "", err

--- a/cmd/pier/main_test.go
+++ b/cmd/pier/main_test.go
@@ -2,9 +2,61 @@ package main
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/usepier/pier/internal/driver"
+	"github.com/usepier/pier/internal/tombstone"
 )
+
+// A failed create used to vanish without trace: the instance rolled itself
+// back and nothing was left to say a session had been asked for at all. The
+// tombstone rides the list so the failure is visible — but only until the
+// cloud can answer for that name itself.
+func TestMergeTombstones(t *testing.T) {
+	live := []driver.Session{{Name: "kur-3814", State: driver.StateIdle}}
+	recs := []tombstone.Record{
+		{Name: "kur-3817", Repo: "flb", Reason: "scp: Connection closed", LogPath: "/tmp/c.log"},
+		{Name: "kur-3814", Reason: "an earlier attempt that has since worked"},
+	}
+
+	merged, revived := mergeTombstones(live, recs)
+	if len(merged) != 2 {
+		t.Fatalf("want the live session plus one tombstone, got %+v", merged)
+	}
+	if merged[0].Name != "kur-3814" || merged[0].State != driver.StateIdle {
+		t.Errorf("a live session must survive the merge untouched, got %+v", merged[0])
+	}
+	got := merged[1]
+	if got.Name != "kur-3817" || got.State != driver.StateFailed {
+		t.Errorf("want kur-3817 as a failed row, got %+v", got)
+	}
+	if got.FailReason == "" || got.LogPath != "/tmp/c.log" {
+		t.Errorf("a tombstone must carry why it died and where to read more, got %+v", got)
+	}
+	if got.CostNote != "—" {
+		t.Errorf("nothing is running, so nothing is billing; got CostNote %q", got.CostNote)
+	}
+	// The obvious next action — re-create it — must clear the row by itself.
+	if len(revived) != 1 || revived[0] != "kur-3814" {
+		t.Errorf("a tombstone whose name came back live must be reported stale, got %v", revived)
+	}
+}
+
+// "create failed" and "setup failed" sit in the same column and mean opposite
+// things: one has no VM at all, the other has a running one whose setup
+// script died. They must never render as the same word.
+func TestStateLabelDistinguishesCreateFromSetupFailure(t *testing.T) {
+	failed := stateLabel(driver.Session{State: driver.StateFailed})
+	if failed != "create failed" {
+		t.Errorf(`want "create failed", got %q`, failed)
+	}
+	setup := stateLabel(driver.Session{State: driver.StateIdle, Setup: "failed"})
+	if !strings.Contains(setup, "idle") || !strings.Contains(setup, "setup failed") {
+		t.Errorf("a live session with a dead setup script must still read as running, got %q", setup)
+	}
+}
 
 func TestRetryAttachOnlyForQuickSSHTransportFailure(t *testing.T) {
 	exit := func(code string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -98,16 +99,56 @@ func Load() (Config, error) {
 	return c, nil
 }
 
+// Save writes the whole config, replacing whatever is on disk. It takes the
+// lock so a write can't interleave with another process's, but it does NOT
+// re-read first — so it reverts anything saved since this Config was loaded.
+// Use Update for anything that changes part of the config; Save is for the
+// setup wizard, which has just asked the user about all of it.
 func (c Config) Save() error {
-	if err := os.MkdirAll(Dir(), 0o755); err != nil {
-		return err
-	}
-	f, err := os.OpenFile(Path(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	unlock, err := lockConfig()
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	return toml.NewEncoder(f).Encode(c)
+	defer unlock()
+	return c.write()
+}
+
+// write is Save without the lock, for callers already holding it.
+//
+// The file holds things no UI can put back: the baked-image map, the secrets
+// manifest, the Claude token. Truncate-then-encode meant a write that died
+// halfway left a short file that still parsed, and the previous contents were
+// gone either way. So: encode to memory first, keep the outgoing version as
+// .bak, and swap the new one in with a rename — a reader always sees one
+// whole version or the other, and the last one stays recoverable.
+func (c Config) write() error {
+	if err := os.MkdirAll(Dir(), 0o755); err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(c); err != nil {
+		return err
+	}
+	if old, err := os.ReadFile(Path()); err == nil && !bytes.Equal(old, buf.Bytes()) {
+		// Best-effort: a config that can't be backed up still saves.
+		_ = os.WriteFile(Path()+".bak", old, 0o600)
+	}
+	tmp, err := os.CreateTemp(Dir(), ".config-*.toml")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name()) // no-op once the rename succeeds
+	if _, err := tmp.Write(buf.Bytes()); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp.Name(), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), Path())
 }
 
 // gcp reports whether the active driver is gcp-gce (anything else falls to

--- a/internal/config/save_test.go
+++ b/internal/config/save_test.go
@@ -1,0 +1,143 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// The config file carries state no UI can reconstruct — the baked-image map
+// above all. A repo whose pointer goes missing launches from stock and fails
+// its setup script minutes later, with nothing connecting the two. So a save
+// must round-trip everything it didn't touch, and must leave the previous
+// version recoverable.
+func TestSaveRoundTripsAndKeepsABackup(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	first := Default()
+	first.RecordBake("flb-estimation", "ami-01ccf62352e7036a2")
+	first.Secrets.ClaudeOAuthToken = "tok"
+	first.Secrets.Manifest = []string{".netrc"}
+	if err := first.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The load → edit → save path every settings write takes.
+	loaded, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Set(&loaded, "idle_timeout", "1h"); err != nil {
+		t.Fatal(err)
+	}
+	if err := loaded.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.IdleTimeout != "1h" {
+		t.Errorf("the edit must land, got idle_timeout %q", got.IdleTimeout)
+	}
+	if img := got.BakedImage("flb-estimation"); img != "ami-01ccf62352e7036a2" {
+		t.Errorf("an unrelated edit must not drop the baked image, got %q", img)
+	}
+	if got.Secrets.ClaudeOAuthToken != "tok" || len(got.Secrets.Manifest) != 1 {
+		t.Errorf("an unrelated edit must not drop secrets, got %+v", got.Secrets)
+	}
+
+	// The version being replaced stays on disk, so a bad write is survivable.
+	bak, err := os.ReadFile(Path() + ".bak")
+	if err != nil {
+		t.Fatalf("want a backup of the previous config: %v", err)
+	}
+	if !contains(string(bak), "ami-01ccf62352e7036a2") {
+		t.Error("the backup must hold the previous contents")
+	}
+}
+
+// A save must never leave a half-written config behind: readers see the old
+// version or the new one, never a truncated file that still parses.
+func TestSaveIsAtomic(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	c := Default()
+	c.RecordBake("repo", "ami-1")
+	if err := c.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Save(); err != nil { // a no-op rewrite must stay clean
+		t.Fatal(err)
+	}
+	ents, err := os.ReadDir(Dir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range ents {
+		switch e.Name() {
+		case "config.toml", "config.toml.bak", "config.toml.lock":
+		default:
+			t.Errorf("save left a stray temp file behind: %q", e.Name())
+		}
+	}
+	fi, err := os.Stat(Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("the config holds secrets; want 0600, got %o", perm)
+	}
+}
+
+// Switching clouds back and forth must not cost anything: each cloud's baked
+// images are scoped to that cloud, and the idle one's map has to survive
+// untouched. Note what the switch DOES change — while the active driver is
+// gcp-gce, a repo baked only on AWS reads as unbaked, so a create launches
+// from stock and its .pier/bake.sh toolchains are simply absent.
+func TestDriverSwitchPreservesTheOtherCloudsBakes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	c := Default()
+	c.RecordBake("flb-estimation", "ami-01ccf62352e7036a2")
+	if err := c.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, drv := range []string{"gcp-gce", "aws-ec2", "gcp-gce", "aws-ec2"} {
+		cfg, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := Set(&cfg, "driver", drv); err != nil {
+			t.Fatal(err)
+		}
+		if err := cfg.Save(); err != nil {
+			t.Fatal(err)
+		}
+		got, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.AWS.BakedAMIs["flb-estimation"] != "ami-01ccf62352e7036a2" {
+			t.Fatalf("driver=%s lost the AWS baked-image map: %v", drv, got.AWS.BakedAMIs)
+		}
+		// The lookup is driver-scoped even though the map survived.
+		want := "ami-01ccf62352e7036a2"
+		if drv == "gcp-gce" {
+			want = ""
+		}
+		if img := got.BakedImage("flb-estimation"); img != want {
+			t.Errorf("driver=%s: BakedImage = %q, want %q", drv, img, want)
+		}
+	}
+}
+
+func contains(hay, needle string) bool {
+	return len(hay) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(hay); i++ {
+			if hay[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -1,0 +1,95 @@
+package config
+
+// update.go: safe concurrent writes.
+//
+// The config is one file rewritten whole on every save, and pier is many
+// short-lived processes plus a long-lived TUI. Load-then-save therefore loses
+// updates: a process that read the file a minute ago writes back what it read,
+// erasing anything recorded in between. The casualty that hurts is the
+// baked-image map, because losing it is silent — the next create launches from
+// the stock image, and the repo's setup script fails minutes later on a
+// toolchain that should have been baked in, with nothing connecting the two
+// events. A bake finishing while a settings page is open, or two `pier bake`
+// runs for different repos overlapping, is all it takes.
+//
+// Update is the fix and the rule: never save a Config that has been sitting in
+// memory. Take the lock, re-read, mutate, write.
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+// lockPath is a sidecar, not the config itself: Save swaps the config in by
+// rename, so a lock held on that inode would stop guarding anything.
+func lockPath() string { return Path() + ".lock" }
+
+// lockTimeout bounds the wait. The critical section is a read, a struct
+// mutation and a rename — microseconds — so anything approaching this is a
+// wedged or crashed process, and blocking a `pier bake` forever on it would
+// be worse than failing with a message that says where to look.
+const lockTimeout = 5 * time.Second
+
+// lockConfig takes the exclusive cross-process lock. flock releases on process
+// exit, so a killed pier leaves nothing stale behind.
+func lockConfig() (func(), error) {
+	if err := os.MkdirAll(Dir(), 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(lockPath(), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() {
+				syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				f.Close()
+			}, nil
+		}
+		if !time.Now().Before(deadline) {
+			f.Close()
+			return nil, fmt.Errorf("config busy: another pier process has held %s for %s", lockPath(), lockTimeout)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// Update re-reads the config under an exclusive lock, applies mutate, and
+// writes the result — so a change lands on top of whatever else has been
+// written since this process last looked, instead of reverting it. It returns
+// the saved config so callers can refresh their copy.
+//
+// Every write that changes one part of the config should go through here.
+// Config.Save is for callers that genuinely own the whole file (the setup
+// wizard, which has just asked about all of it).
+func Update(mutate func(*Config) error) (Config, error) {
+	unlock, err := lockConfig()
+	if err != nil {
+		return Config{}, err
+	}
+	defer unlock()
+
+	c := Default()
+	if _, err := os.Stat(Path()); err == nil {
+		loaded, err := Load()
+		if err != nil {
+			// Refuse rather than reset: overwriting a config we couldn't parse
+			// is how a whole account's setup disappears.
+			return Config{}, fmt.Errorf("%w — fix or remove %s (previous version: %s)",
+				err, Path(), Path()+".bak")
+		}
+		c = loaded
+	}
+	if err := mutate(&c); err != nil {
+		return Config{}, err
+	}
+	if err := c.write(); err != nil {
+		return Config{}, err
+	}
+	return c, nil
+}

--- a/internal/config/update_test.go
+++ b/internal/config/update_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"os"
+	"sync"
+	"testing"
+)
+
+// The bug this exists to prevent: pier is many short-lived processes plus a
+// long-lived TUI, all rewriting one file whole. A process that read the config
+// a minute ago used to write back what it read, erasing anything recorded
+// since. The baked-image map was the casualty that hurt, because losing it is
+// silent — the next create launches from the stock image and the repo's setup
+// script fails minutes later on a toolchain that should have been baked in.
+func TestUpdateDoesNotLoseAConcurrentBake(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	base := Default()
+	base.AWS.Region = "eu-central-1"
+	if err := base.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Terminal A opens the TUI settings page: it reads the config now.
+	stale, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Terminal B finishes `pier bake` and records the image.
+	if _, err := Update(func(c *Config) error {
+		c.RecordBake("flb-estimation", "ami-01ccf62352e7036a2")
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Terminal A now saves an unrelated setting. It must not revert the bake.
+	if _, err := Update(func(c *Config) error { return Set(c, "idle_timeout", "1h") }); err != nil {
+		t.Fatal(err)
+	}
+	_ = stale // the page's own copy is deliberately not what gets written
+
+	got, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if img := got.BakedImage("flb-estimation"); img != "ami-01ccf62352e7036a2" {
+		t.Errorf("an unrelated settings save reverted the bake: BakedImage = %q", img)
+	}
+	if got.IdleTimeout != "1h" {
+		t.Errorf("the setting must still land, got %q", got.IdleTimeout)
+	}
+}
+
+// Two repos baking at once must both survive — the second to finish used to
+// write back a config read before the first one recorded anything.
+func TestConcurrentUpdatesAllLand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := Default().Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := []string{"flb-estimation", "pier", "pier-website", "kuro-app"}
+	var wg sync.WaitGroup
+	errs := make([]error, len(repos))
+	for i, repo := range repos {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = Update(func(c *Config) error {
+				c.RecordBake(repo, "ami-"+repo)
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("%s: %v", repos[i], err)
+		}
+	}
+	got, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, repo := range repos {
+		if img := got.BakedImage(repo); img != "ami-"+repo {
+			t.Errorf("%s was lost by a concurrent write: got %q", repo, img)
+		}
+	}
+}
+
+// A config that won't parse must never be silently replaced with defaults —
+// that would drop the baked images, the manifest and the token in one write,
+// which is precisely the failure this package is hardening against.
+func TestUpdateRefusesToOverwriteAnUnparseableConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := Default().Save(); err != nil {
+		t.Fatal(err)
+	}
+	damaged := "driver = \"aws-ec2\"\n[aws\n"
+	if err := os.WriteFile(Path(), []byte(damaged), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Update(func(c *Config) error { return Set(c, "idle_timeout", "1h") }); err == nil {
+		t.Fatal("want a refusal, not a reset to defaults")
+	}
+	// The damaged file is left alone for the user to fix or remove.
+	b, err := os.ReadFile(Path())
+	if err != nil || string(b) != damaged {
+		t.Errorf("the unparseable config must be left untouched, got %q (%v)", b, err)
+	}
+}

--- a/internal/driver/awsec2/create.go
+++ b/internal/driver/awsec2/create.go
@@ -98,17 +98,8 @@ func (d *Driver) Create(ctx context.Context, spec driver.CreateSpec) (sess *driv
 		progress(n)
 	}
 	for _, p := range pl.Pushes {
-		if err := d.scpTo(ctx, id, p.Local, p.Remote); err != nil {
-			if ctx.Err() != nil {
-				return nil, err
-			}
-			// One retry: the SSM tunnel can drop right as the instance
-			// settles ("lost connection" seconds after waitSSH passed).
-			progress("push interrupted — retrying")
-			time.Sleep(2 * time.Second)
-			if err := d.scpTo(ctx, id, p.Local, p.Remote); err != nil {
-				return nil, err
-			}
+		if err := d.push(ctx, id, p.Local, p.Remote, progress); err != nil {
+			return nil, err
 		}
 	}
 
@@ -135,6 +126,60 @@ func (d *Driver) Create(ctx context.Context, spec driver.CreateSpec) (sess *driv
 		InstanceType: d.InstanceType,
 		CostNote:     costNote(driver.StateRunning, d.InstanceType),
 	}, nil
+}
+
+// pushBackoff is the first pause between push attempts, doubling after each.
+// A var so tests can exercise the retry policy without sleeping through it.
+var pushBackoff = 2 * time.Second
+
+// push copies one payload file, retrying a connection that breaks under it.
+//
+// The window this covers is the worst one in a create: the instance exists
+// and is billing, but nothing on it is ours yet, so any failure here rolls
+// the whole thing back. Two things go wrong at this moment for reasons that
+// have nothing to do with the VM — the SSM tunnel drops as the instance
+// settles (seconds after waitSSH passed), and the laptop's own network
+// flaps, which the direct path feels as a dead route mid-transfer. Both heal
+// on their own in seconds. Neither deserves a destroyed instance, so a
+// transport failure demotes this instance to the tunnel and tries again
+// rather than handing the same broken path back to the retry.
+func (d *Driver) push(ctx context.Context, id, local, remote string, progress func(string)) error {
+	const attempts = 3
+	cp := func(ctx context.Context, id, local, remote string) error {
+		return d.scpTo(ctx, id, local, remote)
+	}
+	if d.scpFn != nil {
+		cp = d.scpFn
+	}
+	if progress == nil {
+		progress = func(string) {}
+	}
+	backoff := pushBackoff
+	var err error
+	for i := range attempts {
+		if err = cp(ctx, id, local, remote); err == nil {
+			return nil
+		}
+		// A cancelled create is the user's decision, not a flaky link.
+		if ctx.Err() != nil {
+			return err
+		}
+		if !transportBroken(err) {
+			return err // the remote refused it; retrying changes nothing
+		}
+		if i == attempts-1 {
+			break
+		}
+		d.demoteDirect(id)
+		progress("push interrupted — retrying over the tunnel")
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+	return err
 }
 
 // launch retries on IAM instance-profile propagation lag (the spike showed

--- a/internal/driver/awsec2/create_test.go
+++ b/internal/driver/awsec2/create_test.go
@@ -1,11 +1,100 @@
 package awsec2
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/usepier/pier/internal/driver"
 )
+
+// A create that dies here destroys its instance, so the push is the one
+// place where a blip on the laptop's network costs a whole VM. It must
+// survive one — and it must not paper over a failure that retrying can't fix.
+func TestPushRetriesBrokenTransportOnly(t *testing.T) {
+	swap(t, &pushBackoff, time.Millisecond)
+
+	t.Run("recovers from a broken connection", func(t *testing.T) {
+		d, calls := newPushDriver(t)
+		d.scpFn = func(_ context.Context, _, _, _ string) error {
+			*calls++
+			if *calls == 1 {
+				return errors.New("ssh: connect to host 3.78.221.163 port 22: Network is unreachable")
+			}
+			return nil
+		}
+		if err := d.push(context.Background(), "i-0abc", "/tmp/x", "/tmp/x", nil); err != nil {
+			t.Fatalf("a recovered transport blip must not fail the push: %v", err)
+		}
+		if *calls != 2 {
+			t.Errorf("want a retry, got %d attempt(s)", *calls)
+		}
+		// The retry must have been steered off the path that just broke.
+		if p, ok := d.dprobe["i-0abc"]; !ok || p.ip != "" {
+			t.Errorf("a broken transport must demote the instance to the tunnel, got %+v", p)
+		}
+	})
+
+	t.Run("gives up on a persistent break", func(t *testing.T) {
+		d, calls := newPushDriver(t)
+		d.scpFn = func(_ context.Context, _, _, _ string) error {
+			*calls++
+			return errors.New("scp: Connection closed")
+		}
+		if err := d.push(context.Background(), "i-0abc", "/tmp/x", "/tmp/x", nil); err == nil {
+			t.Fatal("a push that never lands must fail the create")
+		}
+		if *calls != 3 {
+			t.Errorf("want 3 bounded attempts, got %d", *calls)
+		}
+	})
+
+	t.Run("does not retry a refusal", func(t *testing.T) {
+		d, calls := newPushDriver(t)
+		d.scpFn = func(_ context.Context, _, _, _ string) error {
+			*calls++
+			return errors.New("scp: /tmp/x: Permission denied")
+		}
+		if err := d.push(context.Background(), "i-0abc", "/tmp/x", "/tmp/x", nil); err == nil {
+			t.Fatal("want the refusal surfaced")
+		}
+		if *calls != 1 {
+			t.Errorf("a remote refusal fails identically on a retry; want 1 attempt, got %d", *calls)
+		}
+		if _, demoted := d.dprobe["i-0abc"]; demoted {
+			t.Error("a remote refusal says nothing about the transport — it must not demote")
+		}
+	})
+
+	t.Run("stops when the user cancels", func(t *testing.T) {
+		d, calls := newPushDriver(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		d.scpFn = func(_ context.Context, _, _, _ string) error {
+			*calls++
+			cancel()
+			return errors.New("scp: Connection closed")
+		}
+		if err := d.push(ctx, "i-0abc", "/tmp/x", "/tmp/x", nil); err == nil {
+			t.Fatal("a cancelled push must report the failure")
+		}
+		if *calls != 1 {
+			t.Errorf("ctrl-c is a decision, not a blip; want 1 attempt, got %d", *calls)
+		}
+	})
+}
+
+func newPushDriver(t *testing.T) (*Driver, *int) {
+	t.Helper()
+	return &Driver{StateDir: t.TempDir(), Direct: true}, new(int)
+}
+
+func swap[T any](t *testing.T, p *T, v T) {
+	t.Helper()
+	old := *p
+	*p = v
+	t.Cleanup(func() { *p = old })
+}
 
 // AGE reads the created tag: launch time resets on every resume and the
 // beacon's state changes are even noisier, so create time must ride a tag.

--- a/internal/driver/awsec2/direct.go
+++ b/internal/driver/awsec2/direct.go
@@ -149,6 +149,11 @@ func transportBroken(err error) bool {
 		"no route to host",
 		"connection reset",
 		"connection closed",
+		// Refused mid-create means sshd bounced, not that the port is shut:
+		// waitSSH has already seen it answer. probeDirect treats a refusal
+		// the same way (retry almost immediately), so failing the push on one
+		// would destroy an instance over a service restart.
+		"connection refused",
 		"connection timed out",
 		"operation timed out",
 		"broken pipe",

--- a/internal/driver/awsec2/direct.go
+++ b/internal/driver/awsec2/direct.go
@@ -35,6 +35,11 @@ const (
 	// early boot drops packets instead of refusing them, and writing that
 	// off as a blocked network would lock the connection onto the tunnel.
 	directBootWindow = 3 * time.Minute
+	// How long a transfer that died mid-flight pins its instance to the
+	// tunnel. Long enough to outlast a VPN reconnect or a wifi handover
+	// (the usual causes), short enough that a session doesn't spend the rest
+	// of its life on the slow path for one blip.
+	directDemotion = 2 * time.Minute
 )
 
 type directProbe struct {
@@ -109,6 +114,52 @@ func (d *Driver) dropProbe(id string) {
 	d.dmu.Lock()
 	delete(d.dprobe, id)
 	d.dmu.Unlock()
+}
+
+// demoteDirect pins one instance to the SSM tunnel for a while.
+//
+// The pre-flight probe only proves the path was up a moment ago: it dials
+// once, caches the address for a full TTL, and every later connection trusts
+// that. So a connection that dies mid-transfer would otherwise be retried
+// over the exact same address that just failed — the cache hands it straight
+// back — and the tunnel this file advertises as the automatic fallback never
+// gets a turn. That is how a two-second flap on the laptop's network could
+// fail a create outright. Demotion is what makes the fallback real: the path
+// that just broke is taken out of service, and the retry rides the tunnel.
+func (d *Driver) demoteDirect(id string) {
+	d.dmu.Lock()
+	if d.dprobe == nil {
+		d.dprobe = map[string]directProbe{}
+	}
+	d.dprobe[id] = directProbe{ip: "", until: time.Now().Add(directDemotion)}
+	d.dmu.Unlock()
+}
+
+// transportBroken reports whether err is the connection itself failing rather
+// than the remote command exiting nonzero. Only the former says anything
+// about which path to use next; a remote command that fails would fail
+// identically over the tunnel.
+func transportBroken(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	for _, m := range []string{
+		"network is unreachable", // the local route vanished (VPN flap)
+		"no route to host",
+		"connection reset",
+		"connection closed",
+		"connection timed out",
+		"operation timed out",
+		"broken pipe",
+		"host is down",
+		"host is unreachable",
+	} {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	return false
 }
 
 const directRuleDesc = "pier direct"

--- a/internal/driver/awsec2/direct_test.go
+++ b/internal/driver/awsec2/direct_test.go
@@ -109,14 +109,18 @@ func TestDemoteDirectSendsRetryThroughTunnel(t *testing.T) {
 func TestTransportBroken(t *testing.T) {
 	for in, want := range map[string]bool{
 		"ssh: connect to host 3.78.221.163 port 22: Network is unreachable": true,
-		"scp: Connection closed":                true,
-		"client_loop: send disconnect: Broken pipe": true,
+		"scp: Connection closed":                                     true,
+		"client_loop: send disconnect: Broken pipe":                  true,
 		"ssh: connect to host 10.0.0.1 port 22: Operation timed out": true,
-		"no route to host":                    true,
-		"bootstrap: exit status 1":            false,
-		"scp: /tmp/x: Permission denied":      false,
-		"Error 127: pnpm: No such file":       false,
-		"":                                    false,
+		// waitSSH has already seen sshd answer, so a refusal during the push
+		// is a bounced service, not a shut port — probeDirect reads it the
+		// same way, and destroying an instance over it would be absurd.
+		"ssh: connect to host 10.0.0.1 port 22: Connection refused": true,
+		"no route to host":               true,
+		"bootstrap: exit status 1":       false,
+		"scp: /tmp/x: Permission denied": false,
+		"Error 127: pnpm: No such file":  false,
+		"":                               false,
 	} {
 		if got := transportBroken(errors.New(in)); got != want {
 			t.Errorf("transportBroken(%q) = %v, want %v", in, got, want)

--- a/internal/driver/awsec2/direct_test.go
+++ b/internal/driver/awsec2/direct_test.go
@@ -2,6 +2,7 @@ package awsec2
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -68,6 +69,62 @@ func TestDropProbe(t *testing.T) {
 		t.Error("dropProbe must forget the cached probe")
 	}
 	d.dropProbe("i-0abc") // absent id is a no-op, not a panic
+}
+
+// The regression that cost two sessions: a transfer died on the direct path,
+// and the retry re-read the still-valid probe cache, dialed the same dead
+// address, and failed the create. Demotion must park the instance on the
+// tunnel so the retry actually takes a different route.
+func TestDemoteDirectSendsRetryThroughTunnel(t *testing.T) {
+	d := &Driver{
+		StateDir: t.TempDir(),
+		Direct:   true,
+		dprobe: map[string]directProbe{
+			"i-0abc": {ip: "203.0.113.7", until: time.Now().Add(time.Minute)},
+		},
+	}
+	if opts := strings.Join(d.sshOpts(context.Background(), "i-0abc"), " "); !strings.Contains(opts, "HostName=203.0.113.7") {
+		t.Fatalf("precondition: a live probe should dial direct, got %q", opts)
+	}
+	d.demoteDirect("i-0abc")
+	opts := strings.Join(d.sshOpts(context.Background(), "i-0abc"), " ")
+	if !strings.Contains(opts, "ProxyCommand=aws ssm start-session") {
+		t.Errorf("a demoted instance must ride the tunnel, got %q", opts)
+	}
+	if strings.Contains(opts, "HostName=203.0.113.7") {
+		t.Errorf("a demoted instance must not re-dial the address that just failed, got %q", opts)
+	}
+	// Demotion is temporary: it expires so a healed network goes fast again.
+	if p := d.dprobe["i-0abc"]; p.until.After(time.Now().Add(directDemotion + time.Minute)) {
+		t.Errorf("demotion must expire, got until=%v", p.until)
+	}
+	// An instance never probed before can still be demoted (nil-map safety).
+	(&Driver{}).demoteDirect("i-0new")
+}
+
+// Only a broken connection says anything about which path to use next. A
+// remote command that exits nonzero would do so identically over the tunnel,
+// so retrying it there is pointless — and demoting on it would drag every
+// session onto the slow path for ordinary script failures.
+func TestTransportBroken(t *testing.T) {
+	for in, want := range map[string]bool{
+		"ssh: connect to host 3.78.221.163 port 22: Network is unreachable": true,
+		"scp: Connection closed":                true,
+		"client_loop: send disconnect: Broken pipe": true,
+		"ssh: connect to host 10.0.0.1 port 22: Operation timed out": true,
+		"no route to host":                    true,
+		"bootstrap: exit status 1":            false,
+		"scp: /tmp/x: Permission denied":      false,
+		"Error 127: pnpm: No such file":       false,
+		"":                                    false,
+	} {
+		if got := transportBroken(errors.New(in)); got != want {
+			t.Errorf("transportBroken(%q) = %v, want %v", in, got, want)
+		}
+	}
+	if transportBroken(nil) {
+		t.Error("transportBroken(nil) must be false")
+	}
 }
 
 func TestSanitizeRuleName(t *testing.T) {

--- a/internal/driver/awsec2/driver.go
+++ b/internal/driver/awsec2/driver.go
@@ -61,6 +61,10 @@ type Driver struct {
 
 	callerARN string // cached
 
+	// scpFn overrides the file transfer push uses; nil means real scp. Tests
+	// set it to exercise the retry policy without a VM to copy to.
+	scpFn func(ctx context.Context, id, local, remote string) error
+
 	// direct-connect probe state (direct.go)
 	dmu       sync.Mutex
 	dprobe    map[string]directProbe

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -27,6 +27,11 @@ const (
 	StateParked   State = "parked"   // instance stopped, disk persists
 	StateDeleting State = "deleting" // destroy issued; the cloud is still removing it
 	StateDead     State = "dead"     // terminated/crashed outside our control
+	// StateFailed is a local tombstone, not a machine: the create died before
+	// the session existed and took its half-made instance with it. The row
+	// survives so a failed create leaves a trace instead of a silent gap in
+	// the list; `pier rm` (d in the TUI) dismisses it.
+	StateFailed State = "failed"
 )
 
 // Session is one instance + its persistent disk.
@@ -43,6 +48,12 @@ type Session struct {
 	InstanceType string    // provider machine type; feeds the TUI resize picker
 	Created      time.Time // session creation, not last boot — AGE must never go backward
 	CostNote     string    // honest money: "~$3-4/mo" parked, the type's hourly rate otherwise
+	// FailReason is why a StateFailed tombstone exists — the create error,
+	// verbatim. Empty for every real session.
+	FailReason string
+	// LogPath points a tombstone at its create log. Empty when the create ran
+	// in the foreground and its output went to the terminal instead.
+	LogPath string
 }
 
 // Machine is one row in the TUI's resize picker: a curated instance type

--- a/internal/tombstone/tombstone.go
+++ b/internal/tombstone/tombstone.go
@@ -14,7 +14,10 @@
 package tombstone
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -62,9 +65,95 @@ func Summarize(reason string) string {
 
 func dir(stateDir string) string { return filepath.Join(stateDir, "failed") }
 
-// file keys the record by session name, matching how create names its log.
+// file is where one session's record lives.
 func file(stateDir, name string) string {
-	return filepath.Join(dir(stateDir), strings.ReplaceAll(name, "/", "-")+".json")
+	return filepath.Join(dir(stateDir), FileStem(name)+".json")
+}
+
+// FileStem turns a session name into a file name that is safe, unique and
+// still readable. pier keys two per-session files by name — the create log
+// and the failed-create record — and both need that guarantee.
+//
+// Escaped, not folded. Names may hold both "/" and "-" (see
+// payload.checkName), so mapping one onto the other would give feat/login and
+// feat-login a single file to fight over: one create's output or failure
+// silently replacing the other's, and dismissing one clearing the other.
+// Percent escaping is reversible, so distinct names stay distinct — while a
+// name needing no escaping, which is nearly all of them, is spelled exactly
+// as the user typed it. It also leaves no "/" to walk out of the directory.
+func FileStem(name string) string {
+	var b strings.Builder
+	for _, c := range []byte(name) {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9',
+			c == '.', c == '_', c == '-':
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c) // raw bytes, so no two names escape alike
+		}
+	}
+	s := b.String()
+	if s == "" {
+		return "unnamed"
+	}
+	// Names arrive unvalidated — a create can fail on the name itself, and
+	// that failure still deserves a record — so cap the length rather than
+	// hand the filesystem something it will reject. The digest keeps
+	// truncated forms apart.
+	if len(s) > 120 {
+		sum := sha256.Sum256([]byte(name))
+		s = s[:112] + hex.EncodeToString(sum[:4])
+	}
+	return s
+}
+
+func exists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// freePath is where a displaced record can go without destroying anything:
+// its canonical path, or the first numbered variant that is free. Records are
+// located by the name stored inside them rather than by their file name, so a
+// numbered variant is fully functional — it only has to not collide.
+func freePath(stateDir, name string) string {
+	p := file(stateDir, name)
+	for i := 1; exists(p) && i < 1000; i++ {
+		p = filepath.Join(dir(stateDir), fmt.Sprintf("%s.%d.json", FileStem(name), i))
+	}
+	return p
+}
+
+// entry is one file in the graveyard alongside the record it holds.
+type entry struct {
+	path string
+	rec  Record
+}
+
+// entries reads the graveyard. Unreadable or malformed files are skipped
+// rather than fatal: a corrupt tombstone must never break `pier ls`.
+func entries(stateDir string) []entry {
+	ents, err := os.ReadDir(dir(stateDir))
+	if err != nil {
+		return nil
+	}
+	var out []entry
+	for _, e := range ents {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		p := filepath.Join(dir(stateDir), e.Name())
+		b, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		var r Record
+		if err := json.Unmarshal(b, &r); err != nil || r.Name == "" {
+			continue
+		}
+		out = append(out, entry{path: p, rec: r})
+	}
+	return out
 }
 
 // Write records a failed create. Best-effort by design: a create that already
@@ -81,47 +170,54 @@ func Write(stateDir string, r Record) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(file(stateDir, r.Name), b, 0o600)
+	p := file(stateDir, r.Name)
+	for _, e := range entries(stateDir) {
+		switch {
+		case e.rec.Name == r.Name && e.path != p:
+			// A stale alias for this same session, left by an older naming
+			// scheme. One session, one row.
+			os.Remove(e.path)
+		case e.rec.Name != r.Name && e.path == p:
+			// Our destination holds a different session's record: the old
+			// scheme folded that name onto ours, so feat/login can be sitting
+			// exactly where feat-login now belongs. Move it aside rather than
+			// truncating someone else's failure.
+			os.Rename(e.path, freePath(stateDir, e.rec.Name))
+		}
+	}
+	return os.WriteFile(p, b, 0o600)
 }
 
 // List returns live tombstones, newest first, pruning expired ones as it
 // goes. Unreadable or malformed files are skipped rather than fatal: a
 // corrupt tombstone must never be able to break `pier ls`.
 func List(stateDir string) []Record {
-	ents, err := os.ReadDir(dir(stateDir))
-	if err != nil {
-		return nil
-	}
 	var out []Record
-	for _, e := range ents {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+	for _, e := range entries(stateDir) {
+		if time.Since(e.rec.When) > retention {
+			os.Remove(e.path)
 			continue
 		}
-		p := filepath.Join(dir(stateDir), e.Name())
-		b, err := os.ReadFile(p)
-		if err != nil {
-			continue
-		}
-		var r Record
-		if err := json.Unmarshal(b, &r); err != nil || r.Name == "" {
-			continue
-		}
-		if time.Since(r.When) > retention {
-			os.Remove(p)
-			continue
-		}
-		out = append(out, r)
+		out = append(out, e.rec)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].When.After(out[j].When) })
 	return out
 }
 
-// Dismiss forgets one record. Removing an absent tombstone is success — the
-// caller wanted it gone and it is.
+// Dismiss forgets one record. It matches on the name stored inside each file
+// rather than trusting a path built from the name, so a record written under
+// an older naming scheme still clears — and, more importantly, dismissing
+// feat/login can never delete feat-login's record instead. Removing an absent
+// tombstone is success: the caller wanted it gone and it is.
 func Dismiss(stateDir, name string) error {
-	err := os.Remove(file(stateDir, name))
-	if os.IsNotExist(err) {
-		return nil
+	var firstErr error
+	for _, e := range entries(stateDir) {
+		if e.rec.Name != name {
+			continue
+		}
+		if err := os.Remove(e.path); err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
 	}
-	return err
+	return firstErr
 }

--- a/internal/tombstone/tombstone.go
+++ b/internal/tombstone/tombstone.go
@@ -1,0 +1,127 @@
+// Package tombstone remembers creates that died before the session existed.
+//
+// A failed create still terminates its instance — a half-made VM costs money
+// and can't be resumed into a working session, so leaving it running helps
+// nobody. What was missing was any trace afterwards: the instance vanished,
+// and with it every hint that the user had asked for a session at all. Eight
+// creates would return six sessions and no explanation.
+//
+// A tombstone is that trace: a small local record, written by the create that
+// failed, that rides along in the session list as a failed row until it's
+// dismissed. It holds the reason and a pointer to the create log, so "why did
+// it go" is answerable after the fact. Records are local-only — they describe
+// something that never reached the cloud, so there's nothing to reconcile.
+package tombstone
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// retention bounds the graveyard. A tombstone is a nudge to look at a recent
+// failure, not history worth keeping: after a week the log it points at is
+// stale and the row is just clutter, so List drops it on the next read.
+const retention = 7 * 24 * time.Hour
+
+// Record is one failed create.
+type Record struct {
+	Name    string    `json:"name"`
+	Repo    string    `json:"repo"`
+	Branch  string    `json:"branch"`
+	Driver  string    `json:"driver"`
+	Reason  string    `json:"reason"`   // the create error, verbatim
+	LogPath string    `json:"log_path"` // create log, when the create wrote one
+	When    time.Time `json:"when"`
+}
+
+// Summary is Reason's first line, trimmed for a table cell. The full text
+// stays in the record for `pier logs`-style detail.
+func (r Record) Summary() string { return Summarize(r.Reason) }
+
+// Summarize reduces a create error to one short line. Create errors carry
+// whole bootstrap transcripts; a list row wants the headline.
+func Summarize(reason string) string {
+	s, _, _ := strings.Cut(strings.TrimSpace(reason), "\n")
+	s = strings.TrimPrefix(s, "pier: ")
+	const max = 72
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	// Elide the middle, not the tail. These errors open with the operation
+	// and close with the cause — "scp <long temp path> -> <instance id>: ssh:
+	// connect to host …: Network is unreachable" — and the cause is the half
+	// worth reading. Trimming the end would keep only the temp path.
+	const head = 26
+	return string(r[:head]) + "…" + string(r[len(r)-(max-head-1):])
+}
+
+func dir(stateDir string) string { return filepath.Join(stateDir, "failed") }
+
+// file keys the record by session name, matching how create names its log.
+func file(stateDir, name string) string {
+	return filepath.Join(dir(stateDir), strings.ReplaceAll(name, "/", "-")+".json")
+}
+
+// Write records a failed create. Best-effort by design: a create that already
+// failed must not fail differently because the graveyard is unwritable, so
+// callers ignore the error and the user still sees the create's own message.
+func Write(stateDir string, r Record) error {
+	if err := os.MkdirAll(dir(stateDir), 0o700); err != nil {
+		return err
+	}
+	if r.When.IsZero() {
+		r.When = time.Now()
+	}
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(file(stateDir, r.Name), b, 0o600)
+}
+
+// List returns live tombstones, newest first, pruning expired ones as it
+// goes. Unreadable or malformed files are skipped rather than fatal: a
+// corrupt tombstone must never be able to break `pier ls`.
+func List(stateDir string) []Record {
+	ents, err := os.ReadDir(dir(stateDir))
+	if err != nil {
+		return nil
+	}
+	var out []Record
+	for _, e := range ents {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		p := filepath.Join(dir(stateDir), e.Name())
+		b, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		var r Record
+		if err := json.Unmarshal(b, &r); err != nil || r.Name == "" {
+			continue
+		}
+		if time.Since(r.When) > retention {
+			os.Remove(p)
+			continue
+		}
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].When.After(out[j].When) })
+	return out
+}
+
+// Dismiss forgets one record. Removing an absent tombstone is success — the
+// caller wanted it gone and it is.
+func Dismiss(stateDir, name string) error {
+	err := os.Remove(file(stateDir, name))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/tombstone/tombstone_test.go
+++ b/internal/tombstone/tombstone_test.go
@@ -56,6 +56,185 @@ func TestWriteHandlesSlashedNames(t *testing.T) {
 	}
 }
 
+// Branch names may contain both "/" and "-", so feat/login and feat-login are
+// two different sessions. Folding one to the other would let each silently
+// overwrite the other's failure — and dismissing one would delete the other.
+func TestDistinctNamesThatFoldTogetherKeepSeparateRecords(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, Record{Name: "feat/login", Reason: "slashed"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(dir, Record{Name: "feat-login", Reason: "dashed"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := List(dir); len(got) != 2 {
+		t.Fatalf("want both records, got %d: %+v", len(got), got)
+	}
+
+	// Dismissing one must leave the other completely alone.
+	if err := Dismiss(dir, "feat/login"); err != nil {
+		t.Fatal(err)
+	}
+	got := List(dir)
+	if len(got) != 1 {
+		t.Fatalf("want exactly one survivor, got %+v", got)
+	}
+	if got[0].Name != "feat-login" || got[0].Reason != "dashed" {
+		t.Errorf("dismissed the wrong record: %+v", got[0])
+	}
+}
+
+// Re-failing the same session replaces its row rather than stacking a second
+// one, including when the existing file was written under an older scheme.
+func TestWriteReplacesAnyExistingRecordForTheName(t *testing.T) {
+	d := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(d, "failed"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// What the old slash-folding scheme would have left for feat/login. Only
+	// escaped names differ between the schemes; an unescaped one already
+	// lands on its old path, so there is nothing to clean up there.
+	legacy := filepath.Join(d, "failed", "feat-login.json")
+	if err := os.WriteFile(legacy, []byte(`{"name":"feat/login","reason":"legacy","when":"`+
+		time.Now().Format(time.RFC3339)+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := List(d); len(got) != 1 || got[0].Name != "feat/login" {
+		t.Fatalf("precondition: want the legacy record readable, got %+v", got)
+	}
+
+	if err := Write(d, Record{Name: "feat/login", Reason: "current"}); err != nil {
+		t.Fatal(err)
+	}
+	got := List(d)
+	if len(got) != 1 {
+		t.Fatalf("one session must mean one row, got %+v", got)
+	}
+	if got[0].Reason != "current" {
+		t.Errorf("want the newest reason, got %q", got[0].Reason)
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Error("the record written under the old scheme must be cleaned up")
+	}
+}
+
+// The old scheme's collision is still on disk after an upgrade: feat/login's
+// record can be sitting at exactly the path feat-login now writes to. Writing
+// feat-login must not silently destroy the other session's failure.
+func TestWriteRelocatesADifferentSessionSquattingItsPath(t *testing.T) {
+	d := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(d, "failed"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	squatted := filepath.Join(d, "failed", "feat-login.json") // FileStem("feat-login")
+	if err := os.WriteFile(squatted, []byte(`{"name":"feat/login","reason":"the slashed one","when":"`+
+		time.Now().Format(time.RFC3339)+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Write(d, Record{Name: "feat-login", Reason: "the dashed one"}); err != nil {
+		t.Fatal(err)
+	}
+
+	byName := map[string]string{}
+	for _, r := range List(d) {
+		byName[r.Name] = r.Reason
+	}
+	if len(byName) != 2 {
+		t.Fatalf("both sessions must keep a record, got %+v", byName)
+	}
+	if byName["feat/login"] != "the slashed one" {
+		t.Errorf("the squatting record must be relocated, not destroyed: %+v", byName)
+	}
+	if byName["feat-login"] != "the dashed one" {
+		t.Errorf("the new record must land: %+v", byName)
+	}
+}
+
+// Relocation must never fall back to destroying the record it displaces, even
+// when the obvious destination is itself taken. Records are found by the name
+// inside them, so any free path will do.
+func TestWriteNeverDestroysADisplacedRecord(t *testing.T) {
+	d := t.TempDir()
+	g := filepath.Join(d, "failed")
+	if err := os.MkdirAll(g, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().Format(time.RFC3339)
+	write := func(file, name, reason string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(g, file),
+			[]byte(`{"name":"`+name+`","reason":"`+reason+`","when":"`+stamp+`"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// feat/login squats the path feat-login now wants, and its own canonical
+	// path is already occupied by a third session that legitimately owns it.
+	write("feat-login.json", "feat/login", "displaced")
+	write("feat%2Flogin.json", "feat%2Flogin", "third session")
+
+	if err := Write(d, Record{Name: "feat-login", Reason: "incoming"}); err != nil {
+		t.Fatal(err)
+	}
+
+	byName := map[string]string{}
+	for _, r := range List(d) {
+		byName[r.Name] = r.Reason
+	}
+	if len(byName) != 3 {
+		t.Fatalf("all three records must survive, got %+v", byName)
+	}
+	if byName["feat/login"] != "displaced" {
+		t.Errorf("the displaced record was lost: %+v", byName)
+	}
+	if byName["feat%2Flogin"] != "third session" {
+		t.Errorf("the third session must be untouched: %+v", byName)
+	}
+	if byName["feat-login"] != "incoming" {
+		t.Errorf("the new record must land: %+v", byName)
+	}
+	// And it must still be dismissable from wherever it landed.
+	if err := Dismiss(d, "feat/login"); err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range List(d) {
+		if r.Name == "feat/login" {
+			t.Error("a relocated record must still dismiss")
+		}
+	}
+}
+
+// FileStem keys both the create log and the failed-create record, so any two
+// distinct names must produce distinct stems — and a name that needs no
+// escaping must survive verbatim, since these file names are shown to users.
+func TestFileStemIsInjectiveAndReadable(t *testing.T) {
+	for _, verbatim := range []string{"kur-3814", "feat-login", "v1.2_x", "a"} {
+		if got := FileStem(verbatim); got != verbatim {
+			t.Errorf("FileStem(%q) = %q, want it unchanged", verbatim, got)
+		}
+	}
+
+	names := []string{
+		"feat/login", "feat-login", "feat%2Flogin", "feat%252Flogin",
+		"a/b", "a-b", "a%2Fb", "", "..", "../../etc/passwd",
+		strings.Repeat("x/", 200), strings.Repeat("x/", 199) + "y/",
+	}
+	seen := map[string]string{}
+	for _, n := range names {
+		s := FileStem(n)
+		if prev, dup := seen[s]; dup {
+			t.Errorf("%q and %q both key to %q", prev, n, s)
+		}
+		seen[s] = n
+		if strings.Contains(s, "/") {
+			t.Errorf("FileStem(%q) = %q must not contain a separator", n, s)
+		}
+		if len(s) > 120 {
+			t.Errorf("FileStem(%q) is %d bytes, too long for a file name", n, len(s))
+		}
+	}
+}
+
 func TestListPrunesExpiredAndSortsNewestFirst(t *testing.T) {
 	dir := t.TempDir()
 	Write(dir, Record{Name: "old", Reason: "x", When: time.Now().Add(-retention - time.Hour)})

--- a/internal/tombstone/tombstone_test.go
+++ b/internal/tombstone/tombstone_test.go
@@ -1,0 +1,129 @@
+package tombstone
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteListDismiss(t *testing.T) {
+	dir := t.TempDir()
+	if got := List(dir); len(got) != 0 {
+		t.Fatalf("empty state dir must list nothing, got %v", got)
+	}
+	if err := Write(dir, Record{Name: "kur-3817", Repo: "flb", Reason: "scp: Connection closed"}); err != nil {
+		t.Fatal(err)
+	}
+	got := List(dir)
+	if len(got) != 1 || got[0].Name != "kur-3817" || got[0].Repo != "flb" {
+		t.Fatalf("want the record back, got %+v", got)
+	}
+	// Write stamps When so a record without one still ages out eventually.
+	if got[0].When.IsZero() {
+		t.Error("Write must stamp When")
+	}
+	if err := Dismiss(dir, "kur-3817"); err != nil {
+		t.Fatal(err)
+	}
+	if got := List(dir); len(got) != 0 {
+		t.Fatalf("dismissed record must be gone, got %v", got)
+	}
+	// The caller wanted it gone and it is — absent is not an error.
+	if err := Dismiss(dir, "kur-3817"); err != nil {
+		t.Errorf("dismissing an absent record must succeed, got %v", err)
+	}
+}
+
+// Session names are branch names, so they contain slashes; a record must not
+// escape the graveyard directory or collide with a sibling.
+func TestWriteHandlesSlashedNames(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, Record{Name: "feat/login", Reason: "boom"}); err != nil {
+		t.Fatal(err)
+	}
+	got := List(dir)
+	if len(got) != 1 || got[0].Name != "feat/login" {
+		t.Fatalf("want the slashed name back verbatim, got %+v", got)
+	}
+	ents, _ := os.ReadDir(filepath.Join(dir, "failed"))
+	if len(ents) != 1 || strings.Contains(ents[0].Name(), "/") {
+		t.Errorf("the file name must be flat, got %v", ents)
+	}
+	if err := Dismiss(dir, "feat/login"); err != nil || len(List(dir)) != 0 {
+		t.Errorf("a slashed name must dismiss by the same key, err=%v", err)
+	}
+}
+
+func TestListPrunesExpiredAndSortsNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	Write(dir, Record{Name: "old", Reason: "x", When: time.Now().Add(-retention - time.Hour)})
+	Write(dir, Record{Name: "recent", Reason: "x", When: time.Now().Add(-time.Hour)})
+	Write(dir, Record{Name: "newest", Reason: "x", When: time.Now()})
+
+	got := List(dir)
+	if len(got) != 2 {
+		t.Fatalf("want the expired record pruned, got %+v", got)
+	}
+	if got[0].Name != "newest" || got[1].Name != "recent" {
+		t.Errorf("want newest first, got %s then %s", got[0].Name, got[1].Name)
+	}
+	// Pruning is a delete, not a filter — the file must be gone from disk.
+	if _, err := os.Stat(file(dir, "old")); !os.IsNotExist(err) {
+		t.Error("an expired record must be removed from disk")
+	}
+}
+
+// `pier ls` must survive anything in the graveyard: a corrupt tombstone is
+// worth losing, the session list is not.
+func TestListSkipsUnreadableRecords(t *testing.T) {
+	dir := t.TempDir()
+	Write(dir, Record{Name: "good", Reason: "x"})
+	g := filepath.Join(dir, "failed")
+	os.WriteFile(filepath.Join(g, "broken.json"), []byte("{not json"), 0o600)
+	os.WriteFile(filepath.Join(g, "nameless.json"), []byte(`{"reason":"x"}`), 0o600)
+	os.WriteFile(filepath.Join(g, "notes.txt"), []byte("ignored"), 0o600)
+
+	got := List(dir)
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("want only the readable record, got %+v", got)
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	for in, want := range map[string]string{
+		"pier: scp failed\nscp: Connection closed": "scp failed",
+		"  bootstrap: exit 1  ":                    "bootstrap: exit 1",
+		"":                                         "",
+	} {
+		if got := Summarize(in); got != want {
+			t.Errorf("Summarize(%q) = %q, want %q", in, got, want)
+		}
+	}
+	long := Summarize(strings.Repeat("é", 200))
+	if n := len([]rune(long)); n != 72 {
+		t.Errorf("a long reason must truncate to 72 runes, got %d", n)
+	}
+	if !strings.Contains(long, "…") {
+		t.Errorf("a truncated summary must be marked, got %q", long)
+	}
+}
+
+// The incident this was built for: the cause sits at the end of the line,
+// behind a long temp path. Truncating the tail would keep the path and throw
+// away the only part that explains anything.
+func TestSummarizeKeepsTheCauseNotThePath(t *testing.T) {
+	got := Summarize("pier: scp /var/folders/r2/yxgt1yxd3pvcy5ydh9y0863r0000gn/T/" +
+		"pier-create-2086200156/pier-supervisor -> i-01f4b1c5a08c6863a: " +
+		"ssh: connect to host 3.78.221.163 port 22: Network is unreachable")
+	if !strings.Contains(got, "Network is unreachable") {
+		t.Errorf("the cause must survive truncation, got %q", got)
+	}
+	if !strings.HasPrefix(got, "scp ") {
+		t.Errorf("the operation must survive too, got %q", got)
+	}
+	if n := len([]rune(got)); n != 72 {
+		t.Errorf("want 72 runes, got %d (%q)", n, got)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -403,6 +403,9 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case driver.StateDead:
 			m.status, m.statusBad = s.Name+" is dead — no VM to attach to", false
 			return m, nil
+		case driver.StateFailed:
+			m.status, m.statusBad = s.Name+" never finished creating — n starts it again, d clears the row", false
+			return m, nil
 		case driver.StateParked:
 			if m.opts.Resume == nil {
 				m.status, m.statusBad = s.Name+" is parked — pier attach "+s.Name+" resumes it", false
@@ -432,6 +435,14 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case driver.StateDead:
 				m.status, m.statusBad = s.Name+" is dead — no VM to read the log from", false
 				return m, nil
+			case driver.StateFailed:
+				// The create log is local and outlived the instance, so a
+				// tombstone can still explain itself — as long as the create
+				// wrote one (a foreground create printed to the terminal).
+				if s.LogPath == "" {
+					m.status, m.statusBad = s.Name+": "+s.FailReason, true
+					return m, nil
+				}
 			}
 			m.mode = modeLogs
 			m.logSess, m.logText, m.logLines = s, "", nil
@@ -453,6 +464,10 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "p":
 		if len(m.sessions) > 0 {
 			s := m.sessions[m.cursor]
+			if s.State == driver.StateFailed {
+				m.status, m.statusBad = s.Name+" never finished creating — nothing to pin", false
+				return m, nil
+			}
 			m.loading = true
 			return m, tea.Batch(func() tea.Msg {
 				if err := m.opts.Pin(s); err != nil {
@@ -466,6 +481,10 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			s := m.sessions[m.cursor]
 			if s.State == driver.StateCreating {
 				m.status, m.statusBad = s.Name+" is still setting up — resize once it shows running", false
+				return m, nil
+			}
+			if s.State == driver.StateFailed {
+				m.status, m.statusBad = s.Name+" never finished creating — nothing to resize", false
 				return m, nil
 			}
 			if s.State == driver.StateDeleting {
@@ -620,14 +639,23 @@ func (m model) updateSettingPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // fixed; the config on disk is never touched by a bad value.
 func (m model) saveSetting(val string) (tea.Model, tea.Cmd) {
 	f := config.Settings[m.setIdx]
+	// Validate against the page's copy first so a bad value never reaches
+	// disk and the editor can stay open on it.
 	if err := config.Set(m.cfg, f.Key, val); err != nil {
 		m.status, m.statusBad = err.Error(), true
 		return m, nil
 	}
-	if err := m.cfg.Save(); err != nil {
+	// Then write through Update rather than saving the page's copy: the TUI
+	// can sit on this page while a `pier bake` finishes in another terminal,
+	// and saving a stale struct would erase the image it just recorded.
+	saved, err := config.Update(func(c *config.Config) error {
+		return config.Set(c, f.Key, val)
+	})
+	if err != nil {
 		m.status, m.statusBad = err.Error(), true
 		return m, nil
 	}
+	m.cfg = &saved
 	m.editing, m.picking = false, false
 	m.status, m.statusBad = f.Label+" saved — applies to new sessions", false
 	return m, nil
@@ -785,7 +813,12 @@ func (m model) View() string {
 		b.WriteString(ui.Box.Render(ui.Accent.Render("❯ ")+m.input+ui.Accent.Render("▌")) + "\n")
 		b.WriteString(" " + ui.Keys("enter", "create", "esc", "cancel") + "\n")
 	case modeConfirm:
-		b.WriteString(" " + ui.Warn.Render(fmt.Sprintf("destroy %q and its disk? (y/n)", m.sessions[m.cursor].Name)) + "\n")
+		if s := m.sessions[m.cursor]; s.State == driver.StateFailed {
+			// No disk, no instance — clearing a tombstone destroys nothing.
+			b.WriteString(" " + ui.Warn.Render(fmt.Sprintf("clear the failed create %q? (y/n)", s.Name)) + "\n")
+		} else {
+			b.WriteString(" " + ui.Warn.Render(fmt.Sprintf("destroy %q and its disk? (y/n)", s.Name)) + "\n")
+		}
 	case modeResize:
 		s := m.sessions[m.cursor]
 		b.WriteString(" " + ui.Dim.Render("resize "+s.Name+" — same-arch machines, billed on-demand while running") + "\n")
@@ -1172,10 +1205,16 @@ func stateCell(s driver.Session) string {
 		driver.StateParked:   "◌",
 		driver.StateDeleting: "◌",
 		driver.StateDead:     "✗",
+		driver.StateFailed:   "✗",
 	}
 	dot, ok := dots[s.State]
 	if !ok {
 		dot = "?"
+	}
+	// A tombstone reads "create failed", never a bare "failed" — the row above
+	// it may say "running (setup failed)", and those are not the same thing.
+	if s.State == driver.StateFailed {
+		return dot + " create failed"
 	}
 	cell := dot + " " + string(s.State)
 	if s.Strained {
@@ -1191,7 +1230,7 @@ func stateCell(s driver.Session) string {
 }
 
 func stateStyle(s driver.Session) lipgloss.Style {
-	if s.Setup == "failed" {
+	if s.Setup == "failed" || s.State == driver.StateFailed {
 		return ui.Bad
 	}
 	if s.Strained {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -199,7 +199,21 @@ func Run(newDriver func(config.Config) (driver.Driver, error), printAdminOnly bo
 		fmt.Println(ui.Dim.Render("  = found " + e))
 	}
 
-	if err := cfg.Save(); err != nil {
+	// Write only what the wizard actually asked about. The prompts above can
+	// take minutes, and cfg was read before them — saving it wholesale would
+	// revert anything written meanwhile, including a `pier bake` finishing in
+	// another terminal. Untouched settings (disk size, connection mode, the
+	// baked-image maps) come from disk, not from this stale copy.
+	if _, err := config.Update(func(c *config.Config) error {
+		c.Driver = cfg.Driver
+		c.IdleTimeout = cfg.IdleTimeout
+		c.Secrets = cfg.Secrets
+		c.AWS.Profile, c.AWS.Region = cfg.AWS.Profile, cfg.AWS.Region
+		c.AWS.InstanceType, c.AWS.Subnet = cfg.AWS.InstanceType, cfg.AWS.Subnet
+		c.GCP.Project, c.GCP.Zone = cfg.GCP.Project, cfg.GCP.Zone
+		c.GCP.MachineType = cfg.GCP.MachineType
+		return nil
+	}); err != nil {
 		return err
 	}
 	fmt.Println(ui.Dim.Render("  wrote " + config.Path()))
@@ -240,8 +254,11 @@ func Run(newDriver func(config.Config) (driver.Driver, error), printAdminOnly bo
 		if err != nil {
 			return err
 		}
-		cfg.RecordBake(name, img)
-		if err := cfg.Save(); err != nil {
+		// Update, not Save: the bake just took minutes, and cfg predates it.
+		if _, err := config.Update(func(c *config.Config) error {
+			c.RecordBake(name, img)
+			return nil
+		}); err != nil {
 			return err
 		}
 		fmt.Println("  "+ui.Mark(true), "baked", img, "for", name)


### PR DESCRIPTION
Three related defects, each turning a recoverable condition into silent session or data loss.

**A transient client-side network fault could destroy an instance.** The direct-connect probe caches an instance's address for a full TTL, so a transfer that dies mid-flight is retried against exactly the address the cache hands back — the SSM tunnel documented as the automatic fallback never gets a turn. Any brief interruption on the client's network (a VPN reconnect, a wifi handover) therefore fails the create outright, and a failed create rolls back its own instance. A broken transfer now demotes that instance to the tunnel so the retry takes a different route, and the push gets three bounded attempts instead of one. `transportBroken` distinguishes a dead connection from a remote command exiting nonzero; the latter still fails immediately, since it would fail identically over the tunnel.

**A failed create left no trace.** Destroying the instance is right — a half-made VM costs money and can't be resumed into a working session — but nothing recorded that a session had been attempted, so a create could disappear with no explanation. Deleting was the only option because there was no failed state to leave it in: an instance without the ready tag reads as still-creating everywhere. Creates now leave a local tombstone. The instance is still destroyed, so nothing lingers or bills, but the failure rides the session list until dismissed, carrying why it died and where to read more. It renders as "create failed", never a bare "failed" — neighbouring rows say "setup failed" for a live session whose setup script died, and the two mean opposite things.

**Config writes silently reverted each other.** `config.toml` is rewritten whole on every save, and pier is many short-lived processes plus a long-lived TUI, so load-then-save loses updates: a process that read the file earlier writes back what it read. The baked-image map is the casualty that hurts, because losing it is silent — the next create launches from the stock image and the repo's setup script fails minutes later on a toolchain that should have been baked in, with nothing connecting the two events. A bake finishing while a settings page is open, two bakes for different repos overlapping, or `pier setup` sitting on its prompts is enough to trigger it. `config.Update` now takes a cross-process lock, re-reads from disk, applies the change and writes; every partial write goes through it. The write itself is atomic with a `.bak` sidecar, and a config that won't parse is refused rather than reset to defaults — which would drop the baked images, manifest and token at once.

Also warns before launching when a repo declares a bake hook but has no image for the active driver, covering both a lost image pointer and a switch to a cloud the repo was never baked on.

Tests cover each: tunnel demotion and retry classification, tombstone lifecycle and rendering, lost-update and concurrent-write regressions, and the atomic-write/backup path. `make test` green.
