### PR TITLE
fix(payload): copy untracked files into sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Pier uses one committed `.pier/` directory with three optional files:
 | File | Runs / read | Contains |
 |---|---|---|
 | `.pier/setup.sh` | Every session's first boot, async, in a `setup` tmux window | Repo state: deps, services, migrations, seeds |
-| `.pier/include` | At create | Untracked/ignored files to carry (env files, local certs) |
+| `.pier/include` | At create | Ignored files to carry (env files, local certs) |
 | `.pier/bake.sh` | Once, during `pier bake` | Toolchains beyond the default image (pnpm, python, rust, ...) |
 
 Do not ignore `.pier/`: it is shared project configuration. Loose local files
@@ -319,15 +319,16 @@ when you do).
 
 ### Secrets, deliberately boring
 
-Secrets travel once, at create, as an explicit manifest:
+Local files and secrets travel once, at create, in the files payload:
 
 - `~/.claude`, `~/.codex`, tokens (`gh auth token`, `claude setup-token`)
-- the repo files your `.pier/include` lists
+- non-ignored untracked repo files, plus ignored files your `.pier/include` lists
 
-Nothing loose ships by default. The create prints which env files it is
-*not* carrying. The VM never holds cloud credentials. On AWS its instance
-role carries SSM and nothing else. On GCP it runs with no service account
-at all.
+Untracked files that Git does not ignore ship by default. Ignored files ship
+only when `.pier/include` lists them; create prints which ignored env files it
+is *not* carrying. The VM never holds cloud credentials. On AWS its instance
+role carries SSM and nothing else. On GCP it runs with no service account at
+all.
 
 ### MCP servers, agents, skills
 
@@ -380,8 +381,8 @@ supersedes the old image, and `pier teardown` sweeps them all by tag.
 ### Setup that can't fail silently
 
 `.pier/setup.sh` runs async in its own tmux window on first boot, after the
-checkout, dirty patch, and `.pier/include` files are in place. The outcome
-always surfaces:
+checkout, dirty patch, untracked files, and `.pier/include` extras are in
+place. The outcome always surfaces:
 
 - `pier ls` and the TUI show `(setup running)` or `(setup failed)`
 - `pier logs <session>` prints the log from anywhere, no attach needed

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -260,9 +260,9 @@ and the IAP tunnel are simply slower).
 
 Repo-specific Pier config is committed under `.pier/`; the directory must not
 be ignored. Create reads `.pier/include` on the laptop, `.pier/setup.sh`
-arrives with the git checkout, and bake reads `.pier/bake.sh` directly. Loose
-local files named by `.pier/include` stay protected by the repository's
-`.gitignore`.
+arrives with the git checkout or the untracked-file payload, and bake reads
+`.pier/bake.sh` directly. Ignored local files named by `.pier/include` stay
+protected by the repository's `.gitignore`.
 
 1. **`pier bake`** — prebaked **per-repo** image: agent user, tmux, git, gh,
    docker (with compose + buildx — docker.io alone is the bare engine; the
@@ -286,8 +286,9 @@ local files named by `.pier/include` stay protected by the repository's
 2. **Overlapped create** — launch the instance first; build the git bundle +
    secrets tar while it boots; push and bootstrap the moment sshd answers;
    `.pier/setup.sh` runs asynchronously in a background tmux window while you
-   type to the agent — it starts only after the checkout, dirty patch, and
-   `.pier/include` extras are all in place. `PIER_SETUP_SCRIPT`
+   type to the agent — it starts only after the checkout, dirty patch,
+   non-ignored untracked files, and `.pier/include` extras are all in place.
+   `PIER_SETUP_SCRIPT`
    points it at a different script — relative to the repo root or `~` —
    which travels in the tar and takes precedence over the repo's own.
    The outcome is never silent: the window writes `~/.pier-setup.status`
@@ -317,16 +318,16 @@ local files named by `.pier/include` stay protected by the repository's
    mode, **uncommitted edits to tracked files** ride along too, as one
    binary-safe patch (`git diff HEAD`) applied right after the checkout — the
    session's working tree starts exactly as the laptop's, staged edits
-   arriving unstaged. (Only when the session's base is the laptop's HEAD; a
-   session created off another commit carries no dirty state.) Untracked and
-   ignored files travel **only** when **`.pier/include`** names
+   arriving unstaged. Non-ignored untracked files ride in the files tar and
+   are extracted after checkout + patch. (Both happen only when the session's
+   base is the laptop's HEAD; a session created off another commit carries no
+   dirty state.) Ignored files travel **only** when **`.pier/include`** names
    them: one path or glob per line, matched against the disk with no
-   git-status distinction — listed = travels, extracted after checkout +
-   patch so listed content wins. Directly matched file symlinks are
-   dereferenced into regular files at their repo-relative paths; directory
-   symlinks are not followed. Nothing loose ships by default — no env
-   auto-transfer; the create prints which env files it is *not* carrying so
-   a missing one fails loud at create, not deep in `make dev`.
+   git-status distinction — listed = travels. Directly matched file symlinks
+   are dereferenced into regular files at their repo-relative paths;
+   directory symlinks are not followed. The create prints which ignored env
+   files it is *not* carrying so a missing one fails loud at create, not deep
+   in `make dev`.
 
 Cut for v1 (numbers didn't justify the moving parts): warm pools, mid-create
 quota polling.
@@ -334,14 +335,13 @@ quota polling.
 ## 8. Secrets
 
 One-way copy from the laptop at create; never stored anywhere else, never
-written back. Sources (wizard-detected, confirmed into the manifest):
+written back. Sources:
 
-- repo files named by `.pier/include` (path or glob per line) —
-  the **only** loose-file channel: nothing untracked or ignored ships without
-  a line here (env files included; the create warns about ones left behind).
-  Directly matched file symlinks carry their target contents under the link's
-  repo-relative path. Tracked content arrives with the fetch, dirty edits to
-  it via the patch.
+- non-ignored untracked repo files, automatically, plus ignored files named by
+  `.pier/include` (path or glob per line). The create warns about ignored env
+  files left behind. Directly matched file symlinks carry their target
+  contents under the link's repo-relative path. Tracked content arrives with
+  the fetch, dirty edits to it via the patch.
 - `~/.codex/` (auth.json, config.toml, skills)
 - `~/.claude/` settings, `CLAUDE.md`, agents, skills
 - a GitHub credential for git push/PRs and private-repo fetch: `gh auth

--- a/internal/driver/payload/files.go
+++ b/internal/driver/payload/files.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -120,17 +121,16 @@ func portableMCP(servers map[string]json.RawMessage) map[string]json.RawMessage 
 	return out
 }
 
-// pierIncludeFiles lists the repo files (repo-relative) named by .pier/include
-// — the ONLY loose-file channel: nothing untracked or ignored
-// ships without a line here (tracked content arrives via the fetch, dirty
-// edits to it via the patch). One path or glob per line (relative to the
-// root; * ? [] per segment, no **), # comments, a directory line carries its
-// whole subtree. A file symlink directly matched by a line or glob is
-// dereferenced and carried as a regular file at the symlink's repo-relative
-// path; directory symlinks and nested symlinks discovered while walking a
-// directory are not followed. A listed path travels with no git-status
-// distinction, and the tar extracts after checkout + patch, so listed content
-// wins. No file, or an empty one, means nothing extra travels.
+// pierIncludeFiles lists the repo files (repo-relative) named by .pier/include.
+// It is the opt-in channel for ignored files; non-ignored untracked files
+// travel automatically. One path or glob per line (relative to the root;
+// * ? [] per segment, no **), # comments, a directory line carries its whole
+// subtree. A file symlink directly matched by a line or glob is dereferenced
+// and carried as a regular file at the symlink's repo-relative path; directory
+// symlinks and nested symlinks discovered while walking a directory are not
+// followed. A listed path travels with no git-status distinction, and the tar
+// extracts after checkout + patch, so listed content wins. No file, or an
+// empty one, means no explicit extras travel.
 func pierIncludeFiles(repoRoot string) []string {
 	b, err := os.ReadFile(filepath.Join(repoRoot, ".pier", "include"))
 	if err != nil {
@@ -182,32 +182,63 @@ func pierIncludeFiles(repoRoot string) []string {
 	return out
 }
 
-// envFilesNotCarried is the fail-loud affordance for "no default env
-// transfer": env files the tree has (untracked or ignored, any depth) that
-// the tar is NOT carrying. A session whose app dies on a missing env file
-// should have said so at create. Wholly-ignored dirs collapse (--directory)
-// so node_modules fixtures don't count; tracked ones arrive with the fetch.
+// untrackedFiles returns every non-ignored file Git sees as untracked. These
+// are local work just like edits to tracked files, so sessions created from
+// HEAD carry them automatically. --exclude-standard honors repository,
+// .git/info/exclude, and global ignore rules; ignored files remain available
+// only through the explicit .pier/include channel.
+func untrackedFiles(repoRoot string) ([]string, error) {
+	out, err := exec.Command("git", "-C", repoRoot, "ls-files", "-z", "--others", "--exclude-standard", "--").Output()
+	if err != nil {
+		return nil, fmt.Errorf("listing untracked files: %w", err)
+	}
+	var files []string
+	for _, rel := range strings.Split(string(out), "\x00") {
+		if rel == "" || strings.HasSuffix(rel, "/") || !filepath.IsLocal(rel) {
+			continue
+		}
+		files = append(files, rel)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func mergeRepoFiles(groups ...[]string) []string {
+	seen := map[string]bool{}
+	for _, group := range groups {
+		for _, rel := range group {
+			seen[rel] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for rel := range seen {
+		out = append(out, rel)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// envFilesNotCarried is the fail-loud affordance for ignored env files the
+// tar is NOT carrying. Non-ignored untracked files travel automatically; a
+// session whose app dies on an ignored, unlisted env file should have said so
+// at create. Wholly-ignored dirs collapse (--directory) so node_modules
+// fixtures don't count; tracked ones arrive with the fetch.
 func envFilesNotCarried(repoRoot string, carried []string) []string {
 	have := map[string]bool{}
 	for _, p := range carried {
 		have[p] = true
 	}
+	listing, err := gitOut(repoRoot, "ls-files", "-z", "-o", "-i", "--exclude-standard", "--directory")
+	if err != nil {
+		return nil
+	}
 	var miss []string
-	for _, args := range [][]string{
-		{"ls-files", "-z", "-o", "--exclude-standard"},
-		{"ls-files", "-z", "-o", "-i", "--exclude-standard", "--directory"},
-	} {
-		listing, err := gitOut(repoRoot, args...)
-		if err != nil {
-			return nil
+	for _, p := range strings.Split(listing, "\x00") {
+		if p == "" || strings.HasSuffix(p, "/") {
+			continue
 		}
-		for _, p := range strings.Split(listing, "\x00") {
-			if p == "" || strings.HasSuffix(p, "/") {
-				continue
-			}
-			if ok, _ := filepath.Match(".env*", filepath.Base(p)); ok && !have[p] {
-				miss = append(miss, p)
-			}
+		if ok, _ := filepath.Match(".env*", filepath.Base(p)); ok && !have[p] {
+			miss = append(miss, p)
 		}
 	}
 	sort.Strings(miss)
@@ -236,11 +267,11 @@ func setupScriptOverride(repoRoot string) (path, warn string) {
 }
 
 // buildFilesTar packs, into one tar: manifest files/dirs under $HOME (prefix
-// home/), the repo files named by .pier/include (relative paths kept, prefix
-// repo/), a PIER_SETUP_SCRIPT override (as home/.config/pier/setup.sh), and a
-// generated home/.config/pier/env with the session tokens. The bootstrap
-// extracts the two prefixes to the right places.
-func buildFilesTar(dst string, manifest []string, repoRoot string, env map[string]string, setupSrc string) error {
+// home/), selected repo files (non-ignored untracked files plus .pier/include
+// extras, relative paths kept under repo/), a PIER_SETUP_SCRIPT override (as
+// home/.config/pier/setup.sh), and a generated home/.config/pier/env with the
+// session tokens. The bootstrap extracts the two prefixes to the right places.
+func buildFilesTar(dst string, manifest []string, repoRoot string, repoFiles []string, env map[string]string, setupSrc string) error {
 	f, err := os.Create(dst)
 	if err != nil {
 		return err
@@ -304,7 +335,7 @@ func buildFilesTar(dst string, manifest []string, repoRoot string, env map[strin
 		}
 	}
 
-	for _, rel := range pierIncludeFiles(repoRoot) {
+	for _, rel := range repoFiles {
 		p := filepath.Join(repoRoot, rel)
 		if fi, err := os.Stat(p); err == nil && fi.Mode().IsRegular() {
 			// Widen owner-only modes: the VM's docker daemon is

--- a/internal/driver/payload/git.go
+++ b/internal/driver/payload/git.go
@@ -159,8 +159,8 @@ func gitBundle(repo, sha, dst, ref string, thin bool) error {
 // dirtyPatch captures uncommitted work on tracked files — edits, staged
 // adds, deletions, binary-safe — as one patch the bootstrap applies right
 // after checkout, so the session's working tree starts exactly as the
-// laptop's (staged edits arrive unstaged). Untracked files are
-// .pier/include's business. A clean tree writes nothing.
+// laptop's (staged edits arrive unstaged). Non-ignored untracked files travel
+// alongside this patch in the files tar. A clean tree writes nothing.
 func dirtyPatch(repoRoot, dst string) (bool, error) {
 	out, err := exec.Command("git", "-C", repoRoot, "diff", "--binary", "HEAD").Output()
 	if err != nil {

--- a/internal/driver/payload/payload.go
+++ b/internal/driver/payload/payload.go
@@ -1,9 +1,10 @@
 // Package payload assembles everything a new session VM receives: the
 // repo-transfer decision (github fetch, thin bundle, or full bundle), the
-// dirty-tracked patch, the files tar (secrets manifest + .pier/include extras
-// + session env), the cloud-init user-data, and the bootstrap script that
-// puts it all in place. Cloud-agnostic by construction — drivers launch,
-// push, and run; nothing here knows which cloud is on the other end.
+// dirty-tracked patch, the files tar (secrets manifest + untracked repo files
+// + .pier/include extras + session env), the cloud-init user-data, and the
+// bootstrap script that puts it all in place. Cloud-agnostic by construction
+// — drivers launch, push, and run; nothing here knows which cloud is on the
+// other end.
 package payload
 
 import (
@@ -79,10 +80,12 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 			return nil, fmt.Errorf("bundling %s: %w", spec.Repo, err)
 		}
 	}
-	// Dirty tracked state travels only when the session's base IS the
-	// laptop's HEAD — branching a session off another commit and grafting
-	// today's edits onto it would be a lie about what that base contained.
+	// Local dirty state travels only when the session's base IS the laptop's
+	// HEAD — branching a session off another commit and grafting today's
+	// tracked edits or untracked files onto it would be a lie about what that
+	// base contained.
 	patch := ""
+	var untracked []string
 	if head, _ := gitOut(spec.Repo, "rev-parse", "HEAD"); head == sha {
 		p := filepath.Join(dir, "pier-dirty.patch")
 		switch ok, err := dirtyPatch(spec.Repo, p); {
@@ -91,21 +94,26 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 		case ok:
 			patch = p
 		}
+		untracked, err = untrackedFiles(spec.Repo)
+		if err != nil {
+			return nil, err
+		}
 	}
 	setupSrc, warn := setupScriptOverride(spec.Repo)
 	if warn != "" {
 		progress(warn)
 	}
+	repoFiles := mergeRepoFiles(untracked, pierIncludeFiles(spec.Repo))
 	filesTar := filepath.Join(dir, "pier-files.tar")
-	if err := buildFilesTar(filesTar, manifest, spec.Repo, env, setupSrc); err != nil {
+	if err := buildFilesTar(filesTar, manifest, spec.Repo, repoFiles, env, setupSrc); err != nil {
 		return nil, err
 	}
-	if miss := envFilesNotCarried(spec.Repo, pierIncludeFiles(spec.Repo)); len(miss) > 0 {
+	if miss := envFilesNotCarried(spec.Repo, repoFiles); len(miss) > 0 {
 		name := miss[0]
 		if len(miss) > 1 {
 			name += fmt.Sprintf(" +%d more", len(miss)-1)
 		}
-		progress("not carrying " + name + " — env files travel only when .pier/include lists them")
+		progress("not carrying " + name + " — ignored env files travel only when .pier/include lists them")
 	}
 	supPath := filepath.Join(dir, "pier-supervisor")
 	if err := os.WriteFile(supPath, supervisor, 0o755); err != nil {
@@ -135,6 +143,13 @@ func Build(ctx context.Context, dir string, spec driver.CreateSpec, supervisor [
 	if patch != "" {
 		p.Notes = append(p.Notes, "carrying your uncommitted edits to tracked files")
 		p.Pushes = append(p.Pushes, Push{patch, "/tmp/pier-dirty.patch"})
+	}
+	if len(untracked) > 0 {
+		label := "files"
+		if len(untracked) == 1 {
+			label = "file"
+		}
+		p.Notes = append(p.Notes, fmt.Sprintf("carrying %d untracked %s", len(untracked), label))
 	}
 	home, _ := os.UserHomeDir()
 	if names := OAuthRemotes(home, spec.Repo); len(names) > 0 {

--- a/internal/driver/payload/payload_test.go
+++ b/internal/driver/payload/payload_test.go
@@ -243,10 +243,10 @@ func TestRenderUserDataGuards(t *testing.T) {
 	}
 }
 
-// Nothing loose ships by default — but the create warns about env files it
-// is NOT carrying (untracked or ignored, any depth), minus wholly-ignored
-// dirs (node_modules fixtures), tracked ones (they arrive with the fetch),
-// and whatever .pier/include already carries.
+// Non-ignored untracked files travel automatically. The create warns about
+// ignored env files it is NOT carrying, minus wholly-ignored dirs
+// (node_modules fixtures), tracked ones (they arrive with the fetch), and
+// whatever .pier/include already carries.
 func TestEnvFilesNotCarried(t *testing.T) {
 	root := t.TempDir()
 	git := func(args ...string) {
@@ -277,7 +277,14 @@ func TestEnvFilesNotCarried(t *testing.T) {
 	git("add", ".gitignore", "apps/api/.env.example")
 
 	if files := pierIncludeFiles(root); files != nil {
-		t.Errorf("no .pier/include must mean nothing loose ships, got %v", files)
+		t.Errorf("no .pier/include must mean no explicit extras, got %v", files)
+	}
+	untracked, err := untrackedFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"apps/api/main.go"}; !slices.Equal(untracked, want) {
+		t.Errorf("untrackedFiles = %v, want %v", untracked, want)
 	}
 	got := envFilesNotCarried(root, nil)
 	want := []string{".env", "apps/api/.env", "apps/api/.env.local"}
@@ -292,8 +299,8 @@ func TestEnvFilesNotCarried(t *testing.T) {
 }
 
 // Uncommitted work on tracked files — edits and staged adds — travels as one
-// patch; untracked files don't (that's .pier/include's channel). A clean
-// tree writes no patch at all.
+// patch; untracked files use the files tar instead. A clean tree writes no
+// patch at all.
 func TestDirtyPatch(t *testing.T) {
 	root := t.TempDir()
 	git := func(args ...string) {
@@ -336,11 +343,90 @@ func TestDirtyPatch(t *testing.T) {
 		}
 	}
 	if strings.Contains(string(b), "c.txt") {
-		t.Error("untracked file leaked into the dirty patch")
+		t.Error("untracked file leaked into the tracked-files patch")
 	}
 }
 
-// .pier/include is the only loose-file channel: lines are paths or globs,
+// Every non-ignored untracked file travels automatically; standard Git
+// ignores are the boundary. .pier/include can explicitly opt an ignored file
+// back in, and an untracked .pier/setup.sh itself needs no special case.
+func TestUntrackedFilesTravelAndIgnoredFilesRequireInclude(t *testing.T) {
+	root := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		if out, err := exec.Command("git", append([]string{"-C", root}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git("init", "-q")
+	write(".gitignore", ".env\nignored/\n")
+	write("tracked.txt", "base\n")
+	git("add", ".gitignore", "tracked.txt")
+	git("-c", "user.name=t", "-c", "user.email=t@t", "-c", "commit.gpgsign=false", "commit", "-qm", "init")
+
+	write(".pier/setup.sh", "#!/bin/sh\nmake build\n")
+	write("notes.txt", "local\n")
+	write(".env", "SECRET=1\n")
+	write("ignored/cache.txt", "large\n")
+
+	untracked, err := untrackedFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{".pier/setup.sh", "notes.txt"}; !slices.Equal(untracked, want) {
+		t.Fatalf("untrackedFiles = %v, want %v", untracked, want)
+	}
+
+	write(".pier/include", ".env\n")
+	untracked, err = untrackedFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoFiles := mergeRepoFiles(untracked, pierIncludeFiles(root))
+	wantFiles := []string{".env", ".pier/include", ".pier/setup.sh", "notes.txt"}
+	if !slices.Equal(repoFiles, wantFiles) {
+		t.Fatalf("repo files = %v, want %v", repoFiles, wantFiles)
+	}
+
+	dst := filepath.Join(t.TempDir(), "files.tar")
+	if err := buildFilesTar(dst, nil, root, repoFiles, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	got := []string{}
+	tr := tar.NewReader(f)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(h.Name, "repo/") {
+			got = append(got, strings.TrimPrefix(h.Name, "repo/"))
+		}
+	}
+	if !slices.Equal(got, wantFiles) {
+		t.Errorf("files tar = %v, want %v", got, wantFiles)
+	}
+}
+
+// .pier/include is the ignored-file escape hatch: lines are paths or globs,
 // matched against the disk with no git-status distinction (the fixture isn't
 // even a git repo). Directory lines carry their whole subtree; escapes and
 // comments are dropped.
@@ -418,7 +504,7 @@ func TestPierIncludeDereferencesDirectFileSymlinks(t *testing.T) {
 	}
 
 	dst := filepath.Join(t.TempDir(), "files.tar")
-	if err := buildFilesTar(dst, nil, root, nil, ""); err != nil {
+	if err := buildFilesTar(dst, nil, root, pierIncludeFiles(root), nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	f, err := os.Open(dst)
@@ -468,7 +554,7 @@ func TestFilesTarWidensCarriedModes(t *testing.T) {
 	}
 
 	dst := filepath.Join(t.TempDir(), "files.tar")
-	if err := buildFilesTar(dst, nil, root, nil, ""); err != nil {
+	if err := buildFilesTar(dst, nil, root, pierIncludeFiles(root), nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	f, err := os.Open(dst)

--- a/skills/pier-onboard/SKILL.md
+++ b/skills/pier-onboard/SKILL.md
@@ -14,7 +14,7 @@ directory control the rest:
 |---|---|---|
 | `.pier/bake.sh` | Once, during `pier bake`, on a throwaway instance that becomes the repo's AMI | **Toolchains** — language runtimes, package managers |
 | `.pier/setup.sh` | On every session's first boot, async, after the repo lands | **Repo state** — dependency install, services, migrations, seeds |
-| `.pier/include` | List read at create time; matching files ride to the VM | **Untracked/ignored files** dev needs — env files, local certs |
+| `.pier/include` | List read at create time; matching files ride to the VM | **Ignored files** dev needs — env files, local certs |
 
 Your job: inspect this repo, write the files that apply, protect loose local
 files through `.gitignore`, and tell the user what to run next. All three
@@ -36,9 +36,10 @@ From that, determine:
 2. **The dev-setup sequence** — the commands a human runs after a fresh
    clone (install deps, start services, migrate, seed). That's
    `.pier/setup.sh`.
-3. **Files git doesn't carry** that dev needs — usually `.env*`. That's
-   `.pier/include`. Nothing untracked or gitignored ships unless listed
-   here; pier prints which env files it is *not* carrying at create time.
+3. **Ignored files** that dev needs — usually `.env*`. That's `.pier/include`.
+   Non-ignored untracked files travel automatically when creating from HEAD;
+   ignored files travel only when listed here. Pier prints which ignored env
+   files it is *not* carrying at create time.
 
 ## Step 2 — write `.pier/bake.sh` (only if toolchains are needed)
 
@@ -67,9 +68,10 @@ For apt installs, use `sudo DEBIAN_FRONTEND=noninteractive apt-get install -y �
 ## Step 3 — write `.pier/setup.sh`
 
 Runs asynchronously in a `setup` tmux window on the session's first boot,
-with the repo root as cwd, after the checkout, dirty patch, and
-`.pier/include` files are all in place. The user's secrets env
-(`~/.config/pier/env`) is loaded. Output logs to `~/.pier-setup.log`; a
+with the repo root as cwd, after the checkout, dirty patch, non-ignored
+untracked files, and `.pier/include` extras are all in place. The user's
+secrets env (`~/.config/pier/env`) is loaded. Output logs to
+`~/.pier-setup.log`; a
 nonzero exit shows as `(setup failed)` in `pier ls`, so **let failures
 fail** — start with `set -euo pipefail`, don't swallow errors.
 
@@ -93,7 +95,7 @@ where possible. A bare background process must fully detach —
 when the script ends and SIGHUPs its process group (`nohup` alone does not
 detach it).
 
-## Step 4 — write `.pier/include` (only if loose files are needed)
+## Step 4 — write `.pier/include` (only if ignored files are needed)
 
 One path or glob per line, relative to the repo root. `*`, `?`, `[]` match
 within a path segment — **no `**`**. A directory line carries its whole
@@ -111,11 +113,11 @@ apps/*/.env.local
 Only list what a dev session genuinely needs — everything listed leaves
 the laptop for the VM.
 
-For every untracked local file or path added here, ensure the repository-root
-`.gitignore` ignores it so it cannot be committed accidentally. Add only
+Ensure every loose local file or path added here has a repository-root or
+nested `.gitignore` rule so it cannot be committed accidentally. Add only
 missing rules and preserve all existing content. **Never ignore `.pier/`**:
 the Pier config directory contains project configuration and is meant to be
-committed.
+committed (but a new, not-yet-committed `.pier/setup.sh` still travels).
 
 ## Step 5 — finish
 


### PR DESCRIPTION
## Summary

- copy non-ignored untracked files into sessions created from HEAD
- keep ignored files opt-in through .pier/include
- update payload tests, documentation, and the bundled onboarding skill

## Testing

- go test ./...
- go vet ./...