### PR TITLE
cli: add stable JSON output to pier ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ pier <branch> [base]      new session off base (default HEAD), then attach
     --idle <dur|never>    idle self-park timeout (default 30m)
     --cap <dur|never>     unattended runaway cap (default 8h)
     --no-park             shorthand for --idle never
-pier ls                   plain list (pipeable)
+pier ls [--json]          plain list, or stable JSON for automation
 pier attach <session>     attach (parked sessions auto-resume, ~20-60s)
 pier logs <session>       show the setup script log (-f follows)
 pier rm <session> [-f]    destroy the session and its disk
@@ -210,6 +210,13 @@ pier port <session> <p>   manual port forward (8080:3000 = local:session)
 pier doctor               environment + account checks
 pier teardown             remove all pier groundwork from the account
 ```
+
+For automation, `pier ls --json` writes a JSON array with stable fields:
+`id`, `name`, `repository`, `branch`, `owner`, `provider`, `state`,
+`setup_state`, `strained`, `created_at`, `machine_type`, and `cost_note`.
+`created_at` is an RFC 3339 UTC timestamp, or `null` when unavailable;
+`setup_state` is empty when no running or failed setup is reported. The JSON
+mode writes no ANSI styling or explanatory prose to stdout.
 
 A day with pier:
 

--- a/cmd/pier/main.go
+++ b/cmd/pier/main.go
@@ -74,7 +74,7 @@ var helpSections = []helpSection{
 	{
 		title: "Manage sessions",
 		items: []helpItem{
-			{"pier ls", "list sessions"},
+			{"pier ls [--json]", "list sessions (stable JSON with --json)"},
 			{"pier attach <session>", "attach, resuming first if parked"},
 			{"pier logs <session> [-f]", "show or follow the setup log"},
 			{"pier keep <session>", "disable idle self-parking"},
@@ -118,7 +118,7 @@ func main() {
 	}
 	switch args[0] {
 	case "ls":
-		cmdLS()
+		cmdLS(args[1:])
 	case "attach":
 		cmdAttach(args[1:])
 	case "logs":
@@ -426,11 +426,67 @@ func waitReachable(drv driver.Driver, id string, timeout time.Duration) error {
 
 // --- ls / attach / rm / keep -----------------------------------------------------
 
-func cmdLS() {
+type sessionJSON struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Repository  string       `json:"repository"`
+	Branch      string       `json:"branch"`
+	Owner       string       `json:"owner"`
+	Provider    string       `json:"provider"`
+	State       driver.State `json:"state"`
+	SetupState  string       `json:"setup_state"`
+	Strained    bool         `json:"strained"`
+	CreatedAt   *time.Time   `json:"created_at"`
+	MachineType string       `json:"machine_type"`
+	CostNote    string       `json:"cost_note"`
+}
+
+func parseLSArgs(args []string) (bool, error) {
+	fs := flag.NewFlagSet("ls", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "")
+	if err := fs.Parse(args); err != nil {
+		return false, err
+	}
+	if fs.NArg() != 0 {
+		return false, fmt.Errorf("usage: pier ls [--json]")
+	}
+	return *jsonOutput, nil
+}
+
+func writeSessionsJSON(w io.Writer, sessions []driver.Session) error {
+	items := make([]sessionJSON, 0, len(sessions))
+	for _, s := range sessions {
+		var createdAt *time.Time
+		if !s.Created.IsZero() {
+			created := s.Created.UTC()
+			createdAt = &created
+		}
+		items = append(items, sessionJSON{
+			ID: s.ID, Name: s.Name, Repository: s.Repo, Branch: s.Branch,
+			Owner: s.User, Provider: s.Driver, State: s.State,
+			SetupState: s.Setup, Strained: s.Strained, CreatedAt: createdAt,
+			MachineType: s.InstanceType, CostNote: s.CostNote,
+		})
+	}
+	return json.NewEncoder(w).Encode(items)
+}
+
+func cmdLS(args []string) {
+	jsonOutput, err := parseLSArgs(args)
+	if err != nil {
+		fatal(err)
+	}
 	_, drv := loadDriver()
 	sessions, err := listSessions(drv)
 	if err != nil {
 		fatal(err)
+	}
+	if jsonOutput {
+		if err := writeSessionsJSON(os.Stdout, sessions); err != nil {
+			fatal(err)
+		}
+		return
 	}
 	if len(sessions) == 0 {
 		fmt.Println(ui.Dim.Render("no sessions — start one with `pier <branch>`"))

--- a/cmd/pier/main_test.go
+++ b/cmd/pier/main_test.go
@@ -58,6 +58,48 @@ func TestStateLabelDistinguishesCreateFromSetupFailure(t *testing.T) {
 	}
 }
 
+func TestWriteSessionsJSON(t *testing.T) {
+	created := time.Date(2026, time.August, 14, 9, 30, 0, 0, time.FixedZone("test", 4*60*60))
+	sessions := []driver.Session{{
+		ID: "i-123", Name: "json-output", Repo: "pier", Branch: "feat/json",
+		User: "arn:aws:iam::123:user/test", Driver: "aws-ec2",
+		State: driver.StateWorking, Strained: true, Setup: "running",
+		InstanceType: "t4g.medium", Created: created, CostNote: "~$0.04/h",
+	}}
+
+	var out strings.Builder
+	if err := writeSessionsJSON(&out, sessions); err != nil {
+		t.Fatal(err)
+	}
+	want := `[{"id":"i-123","name":"json-output","repository":"pier","branch":"feat/json","owner":"arn:aws:iam::123:user/test","provider":"aws-ec2","state":"working","setup_state":"running","strained":true,"created_at":"2026-08-14T05:30:00Z","machine_type":"t4g.medium","cost_note":"~$0.04/h"}]` + "\n"
+	if got := out.String(); got != want {
+		t.Fatalf("unexpected JSON output\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestWriteSessionsJSONEmpty(t *testing.T) {
+	var out strings.Builder
+	if err := writeSessionsJSON(&out, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != "[]\n" {
+		t.Fatalf("empty session list must be a JSON array, got %q", got)
+	}
+}
+
+func TestParseLSArgs(t *testing.T) {
+	jsonOutput, err := parseLSArgs([]string{"--json"})
+	if err != nil || !jsonOutput {
+		t.Fatalf("--json should enable JSON output, got json=%v err=%v", jsonOutput, err)
+	}
+	if _, err := parseLSArgs([]string{"extra"}); err == nil {
+		t.Error("positional arguments must be rejected")
+	}
+	if _, err := parseLSArgs([]string{"--unknown"}); err == nil {
+		t.Error("unknown flags must be rejected")
+	}
+}
+
 func TestRetryAttachOnlyForQuickSSHTransportFailure(t *testing.T) {
 	exit := func(code string) error {
 		return exec.Command("sh", "-c", "exit "+code).Run()


### PR DESCRIPTION
## What does this PR do and why?

Adds `pier ls --json` for scripts that need session data without parsing the human-oriented table. The JSON path uses the same bounded supervisor enrichment as the plain list, emits a documented stable schema without ANSI or prose, and keeps the existing plain output path unchanged.

## Related issue

Closes #22

## Tests

- `make test`
- `make build`

## Checklist

- [x] `gofmt -l .` produces no output and `go vet ./...` passes
- [x] `make build` succeeds (if this touches supervisor/session code)
- [x] Tests added or updated for behavior changes
- [x] Docs updated if applicable
